### PR TITLE
Update new `terraform-aws-route53-alias` module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/tf_vanity.git?ref=tags/0.2.1"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.2.2"
   aliases          = "${var.aliases}"
   parent_zone_id   = "${var.parent_zone_id}"
   parent_zone_name = "${var.parent_zone_name}"


### PR DESCRIPTION
## what
* Change `tf_vanity` to `terraform-aws-reoute53-alias`

## why
* Conforming to new TF registry conventions