### PR TITLE
Add TravisCI. Fix CloudFront default certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .terraform/
 
 .idea
+*.iml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+addons:
+  apt:
+    packages:
+      - git
+      - make
+      - curl
+
+install:
+  - make init
+
+script:
+  - make terraform:install
+  - make terraform:get-plugins
+  - make terraform:get-modules
+  - make terraform:lint
+  - make terraform:validate

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL := /bin/bash
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+
+lint:
+	$(SELF) terraform:install terraform:get-modules terraform:get-plugins terraform:lint terraform:validate

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-ht
 https://docs.aws.amazon.com/acm/latest/userguide/acm-regions.html
 > To use an ACM Certificate with Amazon CloudFront, you must request or import the certificate in the US East (N. Virginia) region. ACM Certificates in this region that are associated with a CloudFront distribution are distributed to all the geographic locations configured for that distribution.
 
-This is a fundamental requirement of CloudFront, and you''ll need to request the certificate in `us-east-1` region.
+This is a fundamental requirement of CloudFront, and you will need to request the certificate in `us-east-1` region.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# terraform-aws-cloudfront-s3-cdn
+# terraform-aws-cloudfront-s3-cdn [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-cloudfront-s3-cdn.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-cloudfront-s3-cdn)
 
 Terraform module to easily provision an AWS CloudFront CDN with an S3 or custom origin.
+
 
 ## Usage
 
@@ -14,6 +15,7 @@ module "cdn" {
   parent_zone_name = "${var.parent_zone_name}"
 }
 ```
+
 
 ### Generating ACM Certificate
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ aws acm request-certificate --domain-name example.com --subject-alternative-name
 ```
 
 
+
+__NOTE__:
+
+Although AWS Certificate Manager is supported in many AWS regions, to use an SSL certificate with CloudFront, it should be requested only in US East (N. Virginia) region.
+
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-and-https-requirements.html
+> If you want to require HTTPS between viewers and CloudFront, you must change the AWS region to US East (N. Virginia) in the AWS Certificate Manager console before you request or import a certificate.
+
+https://docs.aws.amazon.com/acm/latest/userguide/acm-regions.html
+> To use an ACM Certificate with Amazon CloudFront, you must request or import the certificate in the US East (N. Virginia) region. ACM Certificates in this region that are associated with a CloudFront distribution are distributed to all the geographic locations configured for that distribution.
+
+This is a fundamental requirement of CloudFront, and you''ll need to request the certificate in `us-east-1` region.
+
+
+
 ## Variables
 
 |  Name                          |  Default               |  Description                                                                                                                                                      | Required |

--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ resource "aws_cloudfront_distribution" "default" {
     acm_certificate_arn            = "${var.acm_certificate_arn}"
     ssl_support_method             = "sni-only"
     minimum_protocol_version       = "TLSv1"
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
   }
 
   default_cache_behavior {

--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,6 @@ resource "aws_cloudfront_distribution" "default" {
     ssl_support_method             = "sni-only"
     minimum_protocol_version       = "TLSv1"
     cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
-
   }
 
   default_cache_behavior {

--- a/main.tf
+++ b/main.tf
@@ -49,10 +49,10 @@ resource "aws_s3_bucket_policy" "default" {
 }
 
 resource "aws_s3_bucket" "origin" {
-  count  = "${signum(length(var.origin_bucket)) == 1 ? 0 : 1}"
-  bucket = "${module.origin_label.id}"
-  acl    = "private"
-  tags   = "${module.origin_label.tags}"
+  count         = "${signum(length(var.origin_bucket)) == 1 ? 0 : 1}"
+  bucket        = "${module.origin_label.id}"
+  acl           = "private"
+  tags          = "${module.origin_label.tags}"
   force_destroy = "${var.origin_force_destroy}"
 
   cors_rule {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,7 @@ variable "namespace" {}
 variable "stage" {}
 
 variable "tags" {
+  type    = "map"
   default = {}
 }
 
@@ -32,7 +33,7 @@ variable "origin_bucket" {
 variable "origin_path" {
   # http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginPath
   description = "(Optional) - An optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin. It must begin with a /. Do not add a / at the end of the path."
-  default = ""
+  default     = ""
 }
 
 variable "origin_force_destroy" {


### PR DESCRIPTION
## what
* `terraform fmt`
* Added `TravisCI`
* Added conditional for `cloudfront_default_certificate`
* Updated `README`

## why
* Terraform lint
* To monitor build status
* If `acm_certificate_arn` or `iam_certificate_id` is specified, `cloudfront_default_certificate` must be set to `false`, otherwise Terraform will try to recreate the certificate on each `plan/apply` 
https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/8
* Added a note to `README` that to use an ACM Certificate with Amazon CloudFront, you must request or import the certificate only in the US East (N. Virginia) region
https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/10


