### PR TITLE
make minimim_protocol_version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Available targets:
 | log_standard_transition_days | Number of days to persist in the standard storage tier before moving to the glacier tier | string | `30` | no |
 | max_ttl | Maximum amount of time (in seconds) that an object is in a CloudFront cache | string | `31536000` | no |
 | min_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | string | `0` | no |
+| minimum_protocol_version | Cloudfront TLS minimum protocol version | string | `TLSv1` | no |
 | name | Name  (e.g. `bastion` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | null | an empty string | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,6 +32,7 @@
 | log_standard_transition_days | Number of days to persist in the standard storage tier before moving to the glacier tier | string | `30` | no |
 | max_ttl | Maximum amount of time (in seconds) that an object is in a CloudFront cache | string | `31536000` | no |
 | min_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | string | `0` | no |
+| minimum_protocol_version | Cloudfront TLS minimum protocol version | string | `TLSv1` | no |
 | name | Name  (e.g. `bastion` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | null | an empty string | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ resource "aws_cloudfront_distribution" "default" {
   viewer_certificate {
     acm_certificate_arn            = "${var.acm_certificate_arn}"
     ssl_support_method             = "sni-only"
-    minimum_protocol_version       = "TLSv1"
+    minimum_protocol_version       = "${var.minimum_protocol_version}"
     cloudfront_default_certificate = "${var.acm_certificate_arn == "" ? true : false}"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "acm_certificate_arn" {
   default     = ""
 }
 
+variable "minimum_protocol_version" {
+  description = "Cloudfront TLS minimum protocol version"
+  default     = "TLSv1"
+}
+
 variable "aliases" {
   type        = "list"
   description = "List of FQDN's - Used to set the Alternate Domain Names (CNAMEs) setting on Cloudfront"


### PR DESCRIPTION
Make minimim_protocol_version configurable.

(I wasn't able to run `make readme` to completion as this repo and/or the included build harness fails due to presupposed binaries (`/bin/bash: gomplate: command not found`) whose origins are not documented)