### PR TITLE
Forwarded headers are needed when using CORS on S3 from cloudfront

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Then you can use this method for supressing the superfluous errors.
 ```
 Available targets:
 
-  help                                This help screen
+  help                                Help screen
   help/all                            Display help for all targets
+  help/short                          This help short screen
   lint                                Lint terraform code
 
 ```
@@ -101,6 +102,7 @@ Available targets:
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Select Enabled if you want CloudFront to begin processing requests as soon as the distribution is created, or select Disabled if you do not want CloudFront to begin processing requests after the distribution is created. | string | `true` | no |
 | forward_cookies | Time in seconds that browser can cache the response for S3 bucket | string | `none` | no |
+| forward_header_values | A list of whitelisted header values to forward to the origin | list | `<list>` | no |
 | forward_query_string | Forward query strings to the origin that is associated with this cache behavior | string | `false` | no |
 | geo_restriction_locations | List of country codes for which  CloudFront either to distribute content (whitelist) or not distribute your content (blacklist) | list | `<list>` | no |
 | geo_restriction_type | Method that use to restrict distribution of your content by country: `none`, `whitelist`, or `blacklist` | string | `none` | no |

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -2,8 +2,9 @@
 ```
 Available targets:
 
-  help                                This help screen
+  help                                Help screen
   help/all                            Display help for all targets
+  help/short                          This help short screen
   lint                                Lint terraform code
 
 ```

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Select Enabled if you want CloudFront to begin processing requests as soon as the distribution is created, or select Disabled if you do not want CloudFront to begin processing requests after the distribution is created. | string | `true` | no |
 | forward_cookies | Time in seconds that browser can cache the response for S3 bucket | string | `none` | no |
+| forward_header_values | A list of whitelisted header values to forward to the origin | list | `<list>` | no |
 | forward_query_string | Forward query strings to the origin that is associated with this cache behavior | string | `false` | no |
 | geo_restriction_locations | List of country codes for which  CloudFront either to distribute content (whitelist) or not distribute your content (blacklist) | list | `<list>` | no |
 | geo_restriction_type | Method that use to restrict distribution of your content by country: `none`, `whitelist`, or `blacklist` | string | `none` | no |

--- a/example/main.tf
+++ b/example/main.tf
@@ -12,6 +12,10 @@ module "cdn" {
   parent_zone_id           = "${aws_route53_zone.primary.zone_id}"
   use_regional_s3_endpoint = "true"
   origin_force_destroy     = "true"
+  cors_allowed_headers = ["*"]
+  cors_allowed_methods = ["GET", "HEAD", "PUT"]
+  cors_allowed_origins = ["*.cloudposse.com"]
+  cors_expose_headers = ["ETag"]
 }
 
 resource "aws_s3_bucket_object" "index" {

--- a/example/main.tf
+++ b/example/main.tf
@@ -12,10 +12,10 @@ module "cdn" {
   parent_zone_id           = "${aws_route53_zone.primary.zone_id}"
   use_regional_s3_endpoint = "true"
   origin_force_destroy     = "true"
-  cors_allowed_headers = ["*"]
-  cors_allowed_methods = ["GET", "HEAD", "PUT"]
-  cors_allowed_origins = ["*.cloudposse.com"]
-  cors_expose_headers = ["ETag"]
+  cors_allowed_headers     = ["*"]
+  cors_allowed_methods     = ["GET", "HEAD", "PUT"]
+  cors_allowed_origins     = ["*.cloudposse.com"]
+  cors_expose_headers      = ["ETag"]
 }
 
 resource "aws_s3_bucket_object" "index" {

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_cloudfront_distribution" "default" {
 
     forwarded_values {
       query_string = "${var.forward_query_string}"
-      headers      = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+      headers      = ["${var.forward_header_values}"]
 
       cookies {
         forward = "${var.forward_cookies}"

--- a/main.tf
+++ b/main.tf
@@ -144,6 +144,7 @@ resource "aws_cloudfront_distribution" "default" {
 
     forwarded_values {
       query_string = "${var.forward_query_string}"
+      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
 
       cookies {
         forward = "${var.forward_cookies}"

--- a/main.tf
+++ b/main.tf
@@ -144,7 +144,7 @@ resource "aws_cloudfront_distribution" "default" {
 
     forwarded_values {
       query_string = "${var.forward_query_string}"
-      headers = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+      headers      = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
 
       cookies {
         forward = "${var.forward_cookies}"

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,12 @@ variable "forward_cookies" {
   description = "Time in seconds that browser can cache the response for S3 bucket"
 }
 
+variable "forward_header_values" {
+  type        = "list"
+  description = "A list of whitelisted header values to forward to the origin"
+  default     = ["Access-Control-Request-Headers", "Access-Control-Request-Method", "Origin"]
+}
+
 variable "price_class" {
   default     = "PriceClass_100"
   description = "Price class for this distribution: `PriceClass_All`, `PriceClass_200`, `PriceClass_100`"


### PR DESCRIPTION
## what:
* Add forwarded headers so that s3 bucket can identify origins.

## why
* Its missing and causes an error

## references
* https://aws.amazon.com/premiumsupport/knowledge-center/no-access-control-allow-origin-error/
