### PR TITLE
Populate local.bucket with aws_s3_bucket resource attributes, not arguments.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ data "aws_s3_bucket" "selected" {
 }
 
 locals {
-  bucket             = "${join("", compact(concat(list(var.origin_bucket), concat(list(""), aws_s3_bucket.origin.*.bucket))))}"
+  bucket             = "${join("", compact(concat(list(var.origin_bucket), concat(list(""), aws_s3_bucket.origin.*.id))))}"
   bucket_domain_name = "${var.use_regional_s3_endpoint == "true" ? format("%s.s3-%s.amazonaws.com" , local.bucket, data.aws_s3_bucket.selected.region): format(var.bucket_domain_format, local.bucket)}"
 }
 


### PR DESCRIPTION
## what
Changing the way bucket_name is populated in locals. Deriving the name from the s3 bucket resource attribute, instead of the s3 bucket argument.

## why
S3 bucket attributes only exist after a resource has been made, currently S3 bucket resource arguments are used to populated a `local`.  This  change will make sure that the `local.bucket` falls back to `var.origin_bucket`. Without this change the datasource `aws_s3_bucket.selected` will try to use a bucket name which has not been created yet.

## references
* closes #31 
