### PR TITLE
Add lambda_function_association

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Available targets:
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | use_regional_s3_endpoint | When set to 'true' the s3 origin_bucket will use the regional endpoint address instead of the global endpoint address | string | `false` | no |
 | viewer_protocol_policy | allow-all, redirect-to-https | string | `redirect-to-https` | no |
+| lambda_function_association | A config block that triggers a lambda function with specific actions | list | `<list>` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -49,6 +49,7 @@
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | use_regional_s3_endpoint | When set to 'true' the s3 origin_bucket will use the regional endpoint address instead of the global endpoint address | string | `false` | no |
 | viewer_protocol_policy | allow-all, redirect-to-https | string | `redirect-to-https` | no |
+| lambda_function_association | A config block that triggers a lambda function with specific actions | list | `<list>` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -153,6 +153,8 @@ resource "aws_cloudfront_distribution" "default" {
     default_ttl            = "${var.default_ttl}"
     min_ttl                = "${var.min_ttl}"
     max_ttl                = "${var.max_ttl}"
+
+    lambda_function_association = ["${var.lambda_function_association}"]
   }
 
   restrictions {

--- a/variables.tf
+++ b/variables.tf
@@ -257,3 +257,9 @@ variable "custom_error_response" {
   type    = "list"
   default = []
 }
+
+variable "lambda_function_association" {
+  type        = "list"
+  default     = []
+  description = "A config block that triggers a lambda function with specific actions"
+}


### PR DESCRIPTION
## Overview
Add lambda_function_association to variables.

## Example

```
module "cdn" {
  source                   = "../"
  namespace                = "eg"
  stage                    = "prod"
  name                     = "app"
  aliases                  = ["assets.cloudposse.com"]
  parent_zone_id           = "${aws_route53_zone.primary.zone_id}"
  use_regional_s3_endpoint = "true"
  origin_force_destroy     = "true"
  cors_allowed_headers     = ["*"]
  cors_allowed_methods     = ["GET", "HEAD", "PUT"]
  cors_allowed_origins     = ["*.cloudposse.com"]
  cors_expose_headers      = ["ETag"]
  lambda_function_association = [
    {
      event_type = "viewer-request"
      lambda_arn = "arn:aws:lambda:us-east-1:${var.account_id}:function:${local.func_name}:12"
    },
  ]
}
```

## Note
When using attributes of your own resource, the following error will be occurred.
https://stackoverflow.com/questions/52202672/terraform-lambda-function-association-for-cloudfront-as-optional-list-within-a-ma

example
```
  lambda_arn = "${aws_lambda_function.some-function.arn}:${aws_lambda_function.some-function.version}"
```

ref. https://github.com/hashicorp/terraform/issues/16582

For the above reason, `lambda_function_association` must be defined directly in the current terraform version.