### PR TITLE
Add wait_for_deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Available targets:
 | trusted_signers | The AWS accounts, if any, that you want to allow to create signed URLs for private content. 'self' is acceptable. | list | `<list>` | no |
 | use_regional_s3_endpoint | When set to 'true' the s3 origin_bucket will use the regional endpoint address instead of the global endpoint address | string | `false` | no |
 | viewer_protocol_policy | allow-all, redirect-to-https | string | `redirect-to-https` | no |
+| wait_for_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | string | `true` | no |
 | web_acl_id | ID of the AWS WAF web ACL that is associated with the distribution | string | `` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -50,6 +50,7 @@
 | trusted_signers | The AWS accounts, if any, that you want to allow to create signed URLs for private content. 'self' is acceptable. | list | `<list>` | no |
 | use_regional_s3_endpoint | When set to 'true' the s3 origin_bucket will use the regional endpoint address instead of the global endpoint address | string | `false` | no |
 | viewer_protocol_policy | allow-all, redirect-to-https | string | `redirect-to-https` | no |
+| wait_for_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | string | `true` | no |
 | web_acl_id | ID of the AWS WAF web ACL that is associated with the distribution | string | `` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -167,6 +167,7 @@ resource "aws_cloudfront_distribution" "default" {
 
   custom_error_response = ["${var.custom_error_response}"]
   web_acl_id            = "${var.web_acl_id}"
+  wait_for_deployment   = "${var.wait_for_deployment}"
 
   tags = "${module.distribution_label.tags}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -275,3 +275,9 @@ variable "web_acl_id" {
   default     = ""
   description = "ID of the AWS WAF web ACL that is associated with the distribution"
 }
+
+variable "wait_for_deployment" {
+  type        = "string"
+  default     = "true"
+  description = "When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed"
+}


### PR DESCRIPTION
Add support for `wait_for_deployment` variable. It has been added to the 2.5.0 AWS terraform provider. 
 
https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#250-april-05-2019