### PR TITLE
var.enabled is a bool not a string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -203,7 +203,7 @@ resource "aws_cloudfront_distribution" "default" {
 
 module "dns" {
   source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.3.0"
-  enabled          = var.enabled == "true" && length(var.parent_zone_id) > 0 || length(var.parent_zone_name) > 0 ? "true" : "false"
+  enabled          = var.enabled && length(var.parent_zone_id) > 0 || length(var.parent_zone_name) > 0 ? true : false
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id
   parent_zone_name = var.parent_zone_name


### PR DESCRIPTION
`var.enabled` been changed to type `bool` but the `dns` module used within this module was still comparing it to a string.

This is causing the DNS record to be removed even when enabled is true and `var.parent_zone_id` is provided.

The `cloudposse/terraform-aws-route53-alias` module has also had it's `var.enabled` changed to type `bool`. 