### PR TITLE
Added the option to add aes256 sse

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Available targets:
 | default_ttl | Default amount of time (in seconds) that an object is in a CloudFront cache | string | `60` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | enabled | Select Enabled if you want CloudFront to begin processing requests as soon as the distribution is created, or select Disabled if you do not want CloudFront to begin processing requests after the distribution is created. | bool | `true` | no |
+| encryption_enabled | When set to 'true' the resource will have aes256 encryption enabled by default | bool | `false` | no |
 | extra_logs_attributes | Additional attributes to put onto the log bucket label | list(string) | `<list>` | no |
 | extra_origin_attributes | Additional attributes to put onto the origin label | list(string) | `<list>` | no |
 | forward_cookies | Time in seconds that browser can cache the response for S3 bucket | string | `none` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 | default_ttl | Default amount of time (in seconds) that an object is in a CloudFront cache | string | `60` | no |
 | delimiter | Delimiter to be used between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | enabled | Select Enabled if you want CloudFront to begin processing requests as soon as the distribution is created, or select Disabled if you do not want CloudFront to begin processing requests after the distribution is created. | bool | `true` | no |
+| encryption_enabled | When set to 'true' the resource will have aes256 encryption enabled by default | bool | `false` | no |
 | extra_logs_attributes | Additional attributes to put onto the log bucket label | list(string) | `<list>` | no |
 | extra_origin_attributes | Additional attributes to put onto the origin label | list(string) | `<list>` | no |
 | forward_cookies | Time in seconds that browser can cache the response for S3 bucket | string | `none` | no |

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,18 @@ resource "aws_s3_bucket" "origin" {
   force_destroy = var.origin_force_destroy
   region        = data.aws_region.current.name
 
+  dynamic "server_side_encryption_configuration" {
+    for_each = var.encryption_enabled ? ["true"] : []
+
+    content {
+      rule {
+        apply_server_side_encryption_by_default {
+          sse_algorithm = "AES256"
+        }
+      }
+    }
+  }
+
   cors_rule {
     allowed_headers = var.cors_allowed_headers
     allowed_methods = var.cors_allowed_methods

--- a/variables.tf
+++ b/variables.tf
@@ -332,3 +332,9 @@ variable "wait_for_deployment" {
   default     = true
   description = "When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed"
 }
+
+variable "encryption_enabled" {
+  type        = bool
+  default     = false
+  description = "When set to 'true' the resource will have aes256 encryption enabled by default"
+}


### PR DESCRIPTION
My org, and I would imagine others, prefers to encrypt s3 buckets even when not entirely necessary just for uniformity in our internal security audits.

This fixes https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/54