### PR TITLE
Fix link to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ module "cdn" {
 }
 ```
 
-Full working example can be found in [example](./example) folder.
+Full working example can be found in [examples](./examples) folder.
 
 ### Generating ACM Certificate
 

--- a/README.yaml
+++ b/README.yaml
@@ -67,7 +67,7 @@ usage: |-
   }
   ```
 
-  Full working example can be found in [example](./example) folder.
+  Full working example can be found in [examples](./examples) folder.
 
   ### Generating ACM Certificate
 


### PR DESCRIPTION
I found a dead link in your readme and fixed it.