### PR TITLE
Added optional support for ipv6 dns records

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Available targets:
 | geo_restriction_locations | List of country codes for which  CloudFront either to distribute content (whitelist) or not distribute your content (blacklist) | list(string) | `<list>` | no |
 | geo_restriction_type | Method that use to restrict distribution of your content by country: `none`, `whitelist`, or `blacklist` | string | `none` | no |
 | index_document | Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders | string | `` | no |
+| ipv6_enabled | Set to true to enable an AAAA DNS record to be set as well as the A record | bool | `false` | no |
 | is_ipv6_enabled | State of CloudFront IPv6 | bool | `true` | no |
 | lambda_function_association | A config block that triggers a lambda function with specific actions | object | `<list>` | no |
 | log_expiration_days | Number of days after which to expunge the objects | string | `90` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -31,6 +31,7 @@
 | geo_restriction_locations | List of country codes for which  CloudFront either to distribute content (whitelist) or not distribute your content (blacklist) | list(string) | `<list>` | no |
 | geo_restriction_type | Method that use to restrict distribution of your content by country: `none`, `whitelist`, or `blacklist` | string | `none` | no |
 | index_document | Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders | string | `` | no |
+| ipv6_enabled | Set to true to enable an AAAA DNS record to be set as well as the A record | bool | `false` | no |
 | is_ipv6_enabled | State of CloudFront IPv6 | bool | `true` | no |
 | lambda_function_association | A config block that triggers a lambda function with specific actions | object | `<list>` | no |
 | log_expiration_days | Number of days after which to expunge the objects | string | `90` | no |

--- a/main.tf
+++ b/main.tf
@@ -249,11 +249,12 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.3.0"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.4.0"
   enabled          = var.enabled && length(var.parent_zone_id) > 0 || length(var.parent_zone_name) > 0 ? true : false
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id
   parent_zone_name = var.parent_zone_name
   target_dns_name  = aws_cloudfront_distribution.default.domain_name
   target_zone_id   = aws_cloudfront_distribution.default.hosted_zone_id
+  ipv6_enabled     = var.ipv6_enabled
 }

--- a/variables.tf
+++ b/variables.tf
@@ -362,3 +362,9 @@ variable "routing_rules" {
   default     = ""
   description = "A json array containing routing rules describing redirect behavior and when redirects are applied"
 }
+
+variable "ipv6_enabled" {
+  type        = bool
+  default     = false
+  description = "Set to true to enable an AAAA DNS record to be set as well as the A record"
+}


### PR DESCRIPTION
This is related to cloudposse/terraform-aws-cloudfront-s3-cdn#64