### PR TITLE
Added support for any number of ordered caches

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Available targets:
 | minimum_protocol_version | Cloudfront TLS minimum protocol version | string | `TLSv1` | no |
 | name | Name  (e.g. `bastion` or `app`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
-| ordered_cache | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0.<br><br>  The fields can be described by the other variables in this file. For example, the field 'lambda_function_association' in this object has   a description in var.lambda_function_association variable earlier in this file. The only difference is that fields on this object are in ordered caches, whereas the rest   of the vars in this file apply only to the default cache. | object | `<list>` | no |
+| ordered_cache | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0. The fields can be described by the other variables in this file. For example, the field 'lambda_function_association' in this object has a description in var.lambda_function_association variable earlier in this file. The only difference is that fields on this object are in ordered caches, whereas the rest of the vars in this file apply only to the default cache. | object | `<list>` | no |
 | origin_bucket | Origin S3 bucket name | string | `` | no |
 | origin_force_destroy | Delete all objects from the bucket  so that the bucket can be destroyed without error (e.g. `true` or `false`) | bool | `false` | no |
 | origin_path | An optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin. It must begin with a /. Do not add a / at the end of the path. | string | `` | no |
@@ -205,7 +205,6 @@ Available targets:
 | viewer_protocol_policy | allow-all, redirect-to-https | string | `redirect-to-https` | no |
 | wait_for_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | bool | `true` | no |
 | web_acl_id | ID of the AWS WAF web ACL that is associated with the distribution | string | `` | no |
-| website_enabled | Set to true to use an S3 static website as origin | bool | `false` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Available targets:
 | error_document | An absolute path to the document to return in case of a 4XX error | string | `` | no |
 | extra_logs_attributes | Additional attributes to put onto the log bucket label | list(string) | `<list>` | no |
 | extra_origin_attributes | Additional attributes to put onto the origin label | list(string) | `<list>` | no |
-| forward_cookies | Time in seconds that browser can cache the response for S3 bucket | string | `none` | no |
+| forward_cookies | Specifies whether you want CloudFront to forward all or no cookies to the origin. Can be 'all' or 'none' | string | `none` | no |
 | forward_header_values | A list of whitelisted header values to forward to the origin | list(string) | `<list>` | no |
 | forward_query_string | Forward query strings to the origin that is associated with this cache behavior | bool | `false` | no |
 | geo_restriction_locations | List of country codes for which  CloudFront either to distribute content (whitelist) or not distribute your content (blacklist) | list(string) | `<list>` | no |
@@ -187,6 +187,7 @@ Available targets:
 | minimum_protocol_version | Cloudfront TLS minimum protocol version | string | `TLSv1` | no |
 | name | Name  (e.g. `bastion` or `app`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
+| ordered_cache | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0.<br><br>  The fields can be described by the other variables in this file. For example, the field 'lambda_function_association' in this object has   a description in var.lambda_function_association variable earlier in this file. The only difference is that fields on this object are in ordered caches, whereas the rest   of the vars in this file apply only to the default cache. | object | `<list>` | no |
 | origin_bucket | Origin S3 bucket name | string | `` | no |
 | origin_force_destroy | Delete all objects from the bucket  so that the bucket can be destroyed without error (e.g. `true` or `false`) | bool | `false` | no |
 | origin_path | An optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin. It must begin with a /. Do not add a / at the end of the path. | string | `` | no |

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Available targets:
 | viewer_protocol_policy | allow-all, redirect-to-https | string | `redirect-to-https` | no |
 | wait_for_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | bool | `true` | no |
 | web_acl_id | ID of the AWS WAF web ACL that is associated with the distribution | string | `` | no |
+| website_enabled | Set to true to use an S3 static website as origin | bool | `false` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -44,7 +44,7 @@
 | minimum_protocol_version | Cloudfront TLS minimum protocol version | string | `TLSv1` | no |
 | name | Name  (e.g. `bastion` or `app`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
-| ordered_cache | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0.<br><br>  The fields can be described by the other variables in this file. For example, the field 'lambda_function_association' in this object has   a description in var.lambda_function_association variable earlier in this file. The only difference is that fields on this object are in ordered caches, whereas the rest   of the vars in this file apply only to the default cache. | object | `<list>` | no |
+| ordered_cache | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0. The fields can be described by the other variables in this file. For example, the field 'lambda_function_association' in this object has a description in var.lambda_function_association variable earlier in this file. The only difference is that fields on this object are in ordered caches, whereas the rest of the vars in this file apply only to the default cache. | object | `<list>` | no |
 | origin_bucket | Origin S3 bucket name | string | `` | no |
 | origin_force_destroy | Delete all objects from the bucket  so that the bucket can be destroyed without error (e.g. `true` or `false`) | bool | `false` | no |
 | origin_path | An optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin. It must begin with a /. Do not add a / at the end of the path. | string | `` | no |
@@ -61,7 +61,6 @@
 | viewer_protocol_policy | allow-all, redirect-to-https | string | `redirect-to-https` | no |
 | wait_for_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | bool | `true` | no |
 | web_acl_id | ID of the AWS WAF web ACL that is associated with the distribution | string | `` | no |
-| website_enabled | Set to true to use an S3 static website as origin | bool | `false` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -25,7 +25,7 @@
 | error_document | An absolute path to the document to return in case of a 4XX error | string | `` | no |
 | extra_logs_attributes | Additional attributes to put onto the log bucket label | list(string) | `<list>` | no |
 | extra_origin_attributes | Additional attributes to put onto the origin label | list(string) | `<list>` | no |
-| forward_cookies | Time in seconds that browser can cache the response for S3 bucket | string | `none` | no |
+| forward_cookies | Specifies whether you want CloudFront to forward all or no cookies to the origin. Can be 'all' or 'none' | string | `none` | no |
 | forward_header_values | A list of whitelisted header values to forward to the origin | list(string) | `<list>` | no |
 | forward_query_string | Forward query strings to the origin that is associated with this cache behavior | bool | `false` | no |
 | geo_restriction_locations | List of country codes for which  CloudFront either to distribute content (whitelist) or not distribute your content (blacklist) | list(string) | `<list>` | no |
@@ -43,6 +43,7 @@
 | minimum_protocol_version | Cloudfront TLS minimum protocol version | string | `TLSv1` | no |
 | name | Name  (e.g. `bastion` or `app`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
+| ordered_cache | An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0.<br><br>  The fields can be described by the other variables in this file. For example, the field 'lambda_function_association' in this object has   a description in var.lambda_function_association variable earlier in this file. The only difference is that fields on this object are in ordered caches, whereas the rest   of the vars in this file apply only to the default cache. | object | `<list>` | no |
 | origin_bucket | Origin S3 bucket name | string | `` | no |
 | origin_force_destroy | Delete all objects from the bucket  so that the bucket can be destroyed without error (e.g. `true` or `false`) | bool | `false` | no |
 | origin_path | An optional element that causes CloudFront to request your content from a directory in your Amazon S3 bucket or your custom origin. It must begin with a /. Do not add a / at the end of the path. | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -61,6 +61,7 @@
 | viewer_protocol_policy | allow-all, redirect-to-https | string | `redirect-to-https` | no |
 | wait_for_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | bool | `true` | no |
 | web_acl_id | ID of the AWS WAF web ACL that is associated with the distribution | string | `` | no |
+| website_enabled | Set to true to use an S3 static website as origin | bool | `false` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -224,6 +224,43 @@ resource "aws_cloudfront_distribution" "default" {
     }
   }
 
+  dynamic "ordered_cache_behavior" {
+    for_each = var.ordered_cache
+
+    content {
+      path_pattern = ordered_cache_behavior.value.path_pattern
+
+      allowed_methods  = ordered_cache_behavior.value.allowed_methods
+      cached_methods   = ordered_cache_behavior.value.cached_methods
+      target_origin_id = module.distribution_label.id
+      compress         = ordered_cache_behavior.value.compress
+      trusted_signers  = ordered_cache_behavior.value.trusted_signers
+
+      forwarded_values {
+        query_string = ordered_cache_behavior.value.forward_query_string
+        headers      = ordered_cache_behavior.value.forward_header_values
+
+        cookies {
+          forward = ordered_cache_behavior.value.forward_cookies
+        }
+      }
+
+      viewer_protocol_policy = ordered_cache_behavior.value.viewer_protocol_policy
+      default_ttl            = ordered_cache_behavior.value.default_ttl
+      min_ttl                = ordered_cache_behavior.value.min_ttl
+      max_ttl                = ordered_cache_behavior.value.max_ttl
+
+      dynamic "lambda_function_association" {
+        for_each = ordered_cache_behavior.value.lambda_function_association
+        content {
+          event_type   = lambda_function_association.value.event_type
+          include_body = lookup(lambda_function_association.value, "include_body", null)
+          lambda_arn   = lambda_function_association.value.lambda_arn
+        }
+      }
+    }
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = var.geo_restriction_type

--- a/variables.tf
+++ b/variables.tf
@@ -402,6 +402,7 @@ The fields can be described by the other variables in this file. For example, th
 a description in var.lambda_function_association variable earlier in this file. The only difference is that fields on this object are in ordered caches, whereas the rest
 of the vars in this file apply only to the default cache.
 DESCRIPTION
+}
 
 variable "website_enabled" {
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -381,9 +381,9 @@ variable "ordered_cache" {
     compress        = bool
 
     viewer_protocol_policy = string
-    min_ttl     = number
-    default_ttl = number
-    max_ttl     = number
+    min_ttl                = number
+    default_ttl            = number
+    max_ttl                = number
 
     forward_query_string  = bool
     forward_header_values = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -193,7 +193,7 @@ variable "cors_max_age_seconds" {
 variable "forward_cookies" {
   type        = string
   default     = "none"
-  description = "Time in seconds that browser can cache the response for S3 bucket"
+  description = "Specifies whether you want CloudFront to forward all or no cookies to the origin. Can be 'all' or 'none'"
 }
 
 variable "forward_header_values" {
@@ -364,4 +364,37 @@ variable "ipv6_enabled" {
   type        = bool
   default     = true
   description = "Set to true to enable an AAAA DNS record to be set as well as the A record"
+}
+
+variable "ordered_cache" {
+  type = list(object({
+    path_pattern = string
+
+    allowed_methods = list(string)
+    cached_methods  = list(string)
+    compress        = bool
+
+    viewer_protocol_policy = string
+    min_ttl     = number
+    default_ttl = number
+    max_ttl     = number
+
+    forward_query_string  = bool
+    forward_header_values = list(string)
+    forward_cookies       = string
+
+    lambda_function_association = list(object({
+      event_type   = string
+      include_body = bool
+      lambda_arn   = string
+    }))
+  }))
+  default     = []
+  description = <<DESCRIPTION
+  An ordered list of cache behaviors resource for this distribution. List from top to bottom in order of precedence. The topmost cache behavior will have precedence 0.
+
+  The fields can be described by the other variables in this file. For example, the field 'lambda_function_association' in this object has
+  a description in var.lambda_function_association variable earlier in this file. The only difference is that fields on this object are in ordered caches, whereas the rest
+  of the vars in this file apply only to the default cache.
+  DESCRIPTION
 }


### PR DESCRIPTION
These ordered caches have the same support, with the same api, as the
default cache already in this module.

This fixes https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/62