### PR TITLE
Empty alias if no acm_certificate_arn given

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -174,7 +174,7 @@ resource "aws_cloudfront_distribution" "default" {
     prefix          = var.log_prefix
   }
 
-  aliases = var.aliases
+  aliases = var.acm_certificate_arn != "" ? var.aliases : []
 
   origin {
     domain_name = local.bucket_domain_name


### PR DESCRIPTION
If we give alias but not give acm_certificate_arn. Will have following error:

> Error: error creating CloudFront Distribution: InvalidViewerCertificate: To add an alternate domain name (CNAME) to a CloudFront distribution, you must attach a trusted certificate that validates your authorization to use the domain name. For more details, see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#alternate-domain-names-requirements

This PR empty alias for cloudfront distribution to avoid this error.