### PR TITLE
Fix origin domain format for S3-backed websites

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ locals {
   )
 
   bucket_domain_name = (var.use_regional_s3_endpoint || var.website_enabled) ? format(
-    var.website_enabled ? "%s.s3-website-%s.amazonaws.com" : "%s.s3-%s.amazonaws.com",
+    var.website_enabled ? "%s.s3-website.%s.amazonaws.com" : "%s.s3.%s.amazonaws.com",
     local.bucket,
     data.aws_s3_bucket.selected.region,
   ) : format(var.bucket_domain_format, local.bucket)


### PR DESCRIPTION
I was so happy to see the `website_enabled` as a config option, but tore my hair out trying to debug the "Failed to contact origin" errors I was getting. Turns out there was a tiny nit in the origin domain that was being set.

2e24291 introduced the `website_enabled` option which sets the origin
domain of the created CloudFront distribution to the Website hosting
URL of the S3 origin bucket.

However, the domain is constructed incorrectly, resulting in:
bucket.s3-website-<region>.amazonaws.com

The correct domain is:
bucket.s3-website.<region>.amazonaws.com