### PR TITLE
S3 website domain name might use `-` or `.`  as concatenator

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,16 @@ locals {
       }
     ]
   }
+
+  regions_s3_website_use_dash = [
+    "us-east-1",
+    "us-west-1",
+    "us-west-2",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ap-northeast-1",
+    "sa-east-1"
+  ]
 }
 
 module "origin_label" {
@@ -170,8 +180,9 @@ locals {
   )
 
   bucket_domain_name = (var.use_regional_s3_endpoint || var.website_enabled) ? format(
-    var.website_enabled ? "%s.s3-website-%s.amazonaws.com" : "%s.s3-%s.amazonaws.com",
+    var.website_enabled ? "%s.s3-website%s%s.amazonaws.com" : "%s.s3%s%s.amazonaws.com",
     local.bucket,
+    (var.website_enabled && contains(local.regions_s3_website_use_dash, data.aws_s3_bucket.selected.region)) ? "-" : ".",
     data.aws_s3_bucket.selected.region,
   ) : format(var.bucket_domain_format, local.bucket)
 }


### PR DESCRIPTION
Fix the issue mentioned in #74 

The s3 static website's domain have [two format][f]:

Format 1:

    http://bucket-name.s3-website.Region.amazonaws.com

Format 2:

    http://bucket-name.s3-website-Region.amazonaws.com

Could be `.` or `-` to concat `s3-website` and region code. And the selection of format is based on region. There is a [mapping table][t] for this. And according to this table. I found only old regions use format 1. Other newer regions all use format 2

In this PR. I created a list of the old regions. And all other regions(including future regions) will use format 2.


[f]: https://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html#root-domain-walkthrough-test-website
[t]:https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints