### PR TITLE
Add `slash-command-dispatch` GitHub Actions workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Use this file to define individuals or teams that are responsible for code in a repository.
+# Read more: <https://help.github.com/articles/about-codeowners/>
+
+* @cloudposse/engineering

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+Found a bug? Maybe our [Slack Community](https://slack.cloudposse.com) can help. 
+
+[![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+## Describe the Bug
+A clear and concise description of what the bug is.
+
+## Expected Behavior
+A clear and concise description of what you expected to happen.
+
+## Steps to Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '....'
+3. Enter '....'
+4. See error
+
+## Screenshots
+If applicable, add screenshots or logs to help explain your problem.
+
+## Environment (please complete the following information):
+
+Anything that will help us triage the bug will help. Here are some ideas:
+ - OS: [e.g. Linux, OSX, WSL, etc]
+ - Version [e.g. 10.15]
+
+## Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+blank_issues_enabled: false
+
+contact_links:
+
+  - name: Community Slack Team
+    url: https://cloudposse.com/slack/
+    about: |-
+      Please ask and answer questions here.
+
+  - name: Office Hours
+    url: https://cloudposse.com/office-hours/
+    about: |-
+      Join us every Wednesday for FREE Office Hours (lunch & learn).
+
+  - name: DevOps Accelerator Program
+    url: https://cloudposse.com/accelerate/
+    about: |-
+      Own your infrastructure in record time. We build it. You drive it. 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature request'
+assignees: ''
+
+---
+
+Have a question? Please checkout our [Slack Community](https://slack.cloudposse.com) in the `#geodesic` channel or visit our [Slack Archive](https://archive.sweetops.com/geodesic/). 
+
+[![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+## Describe the Feature
+
+A clear and concise description of what the bug is. 
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Use Case
+
+Is your feature request related to a problem/challenge you are trying to solve? Please provide some additional context of why this feature or capability will be valuable.
+
+## Describe Ideal Solution
+
+A clear and concise description of what you want to happen. If you don't know, that's okay.
+
+## Alternatives Considered
+
+Explain what alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## what
+* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+* Use bullet points to be concise and to the point.
+
+## why
+* Provide the justifications for the changes (e.g. business case). 
+* Describe why these changes were made (e.g. why do these commits fix the problem?)
+* Use bullet points to be concise and to the point.
+
+## references
+* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+* Use `closes #123`, if this PR closes a GitHub issue `#123`
+

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,20 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Slash Command Dispatch
+        uses: cloudposse/actions/github/slash-command-dispatch@0.12.0
+        with:
+          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: cloudposse/actions
+          commands: rebuild-readme, terraform-fmt
+          permission: none
+          issue-type: pull-request


### PR DESCRIPTION
## what
* Add `slash-command-dispatch` GitHub Actions workflow

## why
* In a repo with the GitHub actions workflow present, when a PR is opened, we can comment on the PR with commands `/build-readme` and `/terraform-fmt` to rebuild README and format terraform code and push the changes back to the PR repo
