### PR TITLE
Fix "minimum field size of 1, PutPublicAccessBlockInput.Bucket" : Cha…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -146,7 +146,7 @@ resource "aws_s3_bucket" "origin" {
 }
 
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.9.0"
+  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.12.0"
   enabled                  = var.logging_enabled
   namespace                = var.namespace
   environment              = var.environment


### PR DESCRIPTION
Got error when disable using logging
* "minimum field size of 1, PutPublicAccessBlockInput.Bucket"
* The version of 'terraform-aws-s3-log-storage' must be 0.12.0

<img width="970" alt="Screenshot 2020-07-17 23 27 38" src="https://user-images.githubusercontent.com/64402672/87809201-309ca800-c885-11ea-84b6-b2e6f96db369.png">
