### PR TITLE
Adding versioning to S3 origin bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Available targets:
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
 | trusted\_signers | The AWS accounts, if any, that you want to allow to create signed URLs for private content. 'self' is acceptable. | `list(string)` | `[]` | no |
 | use\_regional\_s3\_endpoint | When set to 'true' the s3 origin\_bucket will use the regional endpoint address instead of the global endpoint address | `bool` | `false` | no |
+| versioning\_enabled | When set to 'true' the s3 origin bucket will have versioning enabled | `bool` | `false` | no |
 | viewer\_protocol\_policy | allow-all, redirect-to-https | `string` | `"redirect-to-https"` | no |
 | wait\_for\_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | `bool` | `true` | no |
 | web\_acl\_id | ID of the AWS WAF web ACL that is associated with the distribution | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -78,7 +78,7 @@
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
 | trusted\_signers | The AWS accounts, if any, that you want to allow to create signed URLs for private content. 'self' is acceptable. | `list(string)` | `[]` | no |
 | use\_regional\_s3\_endpoint | When set to 'true' the s3 origin\_bucket will use the regional endpoint address instead of the global endpoint address | `bool` | `false` | no |
-| versioning_enabled | When set to 'true' the s3 origin\_bucket will have versioning enabled | `bool` | `false` | no |
+| versioning_enabled | When set to 'true' the s3 origin bucket will have versioning enabled | `bool` | `false` | no |
 | viewer\_protocol\_policy | allow-all, redirect-to-https | `string` | `"redirect-to-https"` | no |
 | wait\_for\_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | `bool` | `true` | no |
 | web\_acl\_id | ID of the AWS WAF web ACL that is associated with the distribution | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -78,6 +78,7 @@
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
 | trusted\_signers | The AWS accounts, if any, that you want to allow to create signed URLs for private content. 'self' is acceptable. | `list(string)` | `[]` | no |
 | use\_regional\_s3\_endpoint | When set to 'true' the s3 origin\_bucket will use the regional endpoint address instead of the global endpoint address | `bool` | `false` | no |
+| versioning | When set to 'true' the s3 origin\_bucket will have versioning enabled | `bool` | `false` | no |
 | viewer\_protocol\_policy | allow-all, redirect-to-https | `string` | `"redirect-to-https"` | no |
 | wait\_for\_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | `bool` | `true` | no |
 | web\_acl\_id | ID of the AWS WAF web ACL that is associated with the distribution | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -78,7 +78,7 @@
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
 | trusted\_signers | The AWS accounts, if any, that you want to allow to create signed URLs for private content. 'self' is acceptable. | `list(string)` | `[]` | no |
 | use\_regional\_s3\_endpoint | When set to 'true' the s3 origin\_bucket will use the regional endpoint address instead of the global endpoint address | `bool` | `false` | no |
-| versioning | When set to 'true' the s3 origin\_bucket will have versioning enabled | `bool` | `false` | no |
+| versioning_enabled | When set to 'true' the s3 origin\_bucket will have versioning enabled | `bool` | `false` | no |
 | viewer\_protocol\_policy | allow-all, redirect-to-https | `string` | `"redirect-to-https"` | no |
 | wait\_for\_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | `bool` | `true` | no |
 | web\_acl\_id | ID of the AWS WAF web ACL that is associated with the distribution | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -78,7 +78,7 @@
 | tags | Additional tags (e.g. map(`BusinessUnit`,`XYZ`) | `map(string)` | `{}` | no |
 | trusted\_signers | The AWS accounts, if any, that you want to allow to create signed URLs for private content. 'self' is acceptable. | `list(string)` | `[]` | no |
 | use\_regional\_s3\_endpoint | When set to 'true' the s3 origin\_bucket will use the regional endpoint address instead of the global endpoint address | `bool` | `false` | no |
-| versioning_enabled | When set to 'true' the s3 origin bucket will have versioning enabled | `bool` | `false` | no |
+| versioning\_enabled | When set to 'true' the s3 origin bucket will have versioning enabled | `bool` | `false` | no |
 | viewer\_protocol\_policy | allow-all, redirect-to-https | `string` | `"redirect-to-https"` | no |
 | wait\_for\_deployment | When set to 'true' the resource will wait for the distribution status to change from InProgress to Deployed | `bool` | `true` | no |
 | web\_acl\_id | ID of the AWS WAF web ACL that is associated with the distribution | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -124,10 +124,10 @@ resource "aws_s3_bucket" "origin" {
   }
 
   dynamic "versioning" {
-    for_each = var.versioning_enabled ? ["true"] : []
+    for_each = [var.versioning_enabled]
 
     content {
-      enabled = var.versioning_enabled
+      enabled = versioning.value
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -123,6 +123,14 @@ resource "aws_s3_bucket" "origin" {
     }
   }
 
+  dynamic "versioning" {
+    for_each = var.versioning_enabled ? ["true"] : []
+
+    content {
+      enabled = var.versioning_enabled
+    }
+  }
+
   dynamic "website" {
     for_each = var.website_enabled ? local.website_config[var.redirect_all_requests_to == "" ? "default" : "redirect_all"] : []
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -440,3 +440,9 @@ variable "website_enabled" {
   default     = false
   description = "Set to true to use an S3 static website as origin"
 }
+
+variable "versioning_enabled" {
+  type        = bool
+  default     = false
+  description = "When set to 'true' the s3 origin\_bucket will have versioning enabled"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -444,5 +444,5 @@ variable "website_enabled" {
 variable "versioning_enabled" {
   type        = bool
   default     = false
-  description = "When set to 'true' the s3 origin\_bucket will have versioning enabled"
+  description = "When set to 'true' the s3 origin bucket will have versioning enabled"
 }


### PR DESCRIPTION
## what
* This change allows you to turn on versioning for objects in the bucket

## why
* For building static websites, we require the use of s3+cdn that this module provides. However, in some instances, we would like to ability to roll back to a previous version. 
* Since this is meant for a "dev" like environment, we set the cdn ttl to very low to pull objects back from the s3 bucket.
* The reason we use the CDN is to support TLS since s3 does not.

## references
* N/A

