### PR TITLE
Add existing cloudfront origin access identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | bucket\_domain\_format | Format of bucket domain name | `string` | `"%s.s3.amazonaws.com"` | no |
 | cached\_methods | List of cached methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br>  "GET",<br>  "HEAD"<br>]</pre> | no |
+| cloudfront\_origin\_access\_identity\_iam\_arn | Existing cloudfront origin access identity iam arn that is supplied in the s3 bucket policy | `string` | `""` | no |
+| cloudfront\_origin\_access\_identity\_path | Existing cloudfront origin access identity path used in the cloudfront distribution's s3\_origin\_config content | `string` | `""` | no |
 | comment | Comment for the origin access identity | `string` | `"Managed by Terraform"` | no |
 | compress | Compress content for web requests that include Accept-Encoding: gzip in the request header | `bool` | `false` | no |
 | cors\_allowed\_headers | List of allowed headers for S3 bucket | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,6 +26,8 @@
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | bucket\_domain\_format | Format of bucket domain name | `string` | `"%s.s3.amazonaws.com"` | no |
 | cached\_methods | List of cached methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br>  "GET",<br>  "HEAD"<br>]</pre> | no |
+| cloudfront\_origin\_access\_identity\_iam\_arn | Existing cloudfront origin access identity iam arn that is supplied in the s3 bucket policy | `string` | `""` | no |
+| cloudfront\_origin\_access\_identity\_path | Existing cloudfront origin access identity path used in the cloudfront distribution's s3\_origin\_config content | `string` | `""` | no |
 | comment | Comment for the origin access identity | `string` | `"Managed by Terraform"` | no |
 | compress | Compress content for web requests that include Accept-Encoding: gzip in the request header | `bool` | `false` | no |
 | cors\_allowed\_headers | List of allowed headers for S3 bucket | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -182,7 +182,7 @@ data "aws_s3_bucket" "selected" {
 locals {
   using_existing_origin = signum(length(var.origin_bucket)) == 1
 
-  using_existing_cloudfront_origin = var.cloudfront_origin_access_identity_iam_arn != "" && var.cloudfront_access_identity_path != ""
+  using_existing_cloudfront_origin = var.cloudfront_origin_access_identity_iam_arn != "" && var.cloudfront_origin_access_identity_path != ""
 
   bucket = join("",
     compact(
@@ -225,7 +225,7 @@ resource "aws_cloudfront_distribution" "default" {
     dynamic "s3_origin_config" {
       for_each = ! var.website_enabled ? [1] : []
       content {
-        origin_access_identity = local.using_existing_cloudfront_origin ? var.cloudfront_access_identity_path : join("", aws_cloudfront_origin_access_identity.default.*.cloudfront_access_identity_path)
+        origin_access_identity = local.using_existing_cloudfront_origin ? var.cloudfront_origin_access_identity_path : join("", aws_cloudfront_origin_access_identity.default.*.cloudfront_access_identity_path)
       }
     }
 

--- a/variables.tf
+++ b/variables.tf
@@ -440,3 +440,15 @@ variable "website_enabled" {
   default     = false
   description = "Set to true to use an S3 static website as origin"
 }
+
+variable "cloudfront_origin_access_identity_iam_arn" {
+  type        = string
+  default     = ""
+  description = "Existing cloudfront origin access identity iam arn that is supplied in the s3 bucket policy"
+}
+
+variable "cloudfront_origin_access_identity_path" {
+  type        = string
+  default     = ""
+  description = "Existing cloudfront origin access identity path used in the cloudfront distribution's s3_origin_config content"
+}


### PR DESCRIPTION
## what
* Allow reusing an existing cloudfront origin access identity

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#private-content-creating-oai-console

> If you already have an OAI, we recommend that you reuse it to simplify maintenance.

## why
* So you don't have to create new cloudfront origin access identities

## references
N/A

