### PR TITLE
Updated dependency module versions to latest

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -148,7 +148,7 @@ resource "aws_s3_bucket" "origin" {
 }
 
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.12.0"
+  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.13.1"
   enabled                  = var.logging_enabled
   namespace                = var.namespace
   environment              = var.environment
@@ -356,7 +356,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.4.0"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.8.0"
   enabled          = var.enabled && (var.parent_zone_id != "" || var.parent_zone_name != "") ? true : false
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id


### PR DESCRIPTION
## what
* Updated dependency modules to latest to support terraform 0.13.0

## why
* Updated the dependency modules since they are not updated and facing error when using with Terraform 0.13.0

### Dependency modules and versions:
- logs -> 0.13.1
- dns -> 0.8.0