### PR TITLE
Remove the v prefix

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -1,4 +1,4 @@
-name-template: 'v$RESOLVED_VERSION'
+name-template: '$RESOLVED_VERSION'
 tag-template: '$RESOLVED_VERSION'
 version-template: '$MAJOR.$MINOR.$PATCH'
 version-resolver:


### PR DESCRIPTION
## what
Remove the v prefix to keep releases consistent

## why
* Consistency

## references
* @Makeshift pointed this out earlier today

