### PR TITLE
use minimum versions for provider pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,22 +124,23 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
-| template | ~> 2.0 |
+| aws | >= 2.0 |
+| template | >= 2.0 |
 
 ## Inputs
 
@@ -228,6 +229,7 @@ Available targets:
 | s3\_bucket\_arn | ARN of S3 bucket |
 | s3\_bucket\_domain\_name | Domain of S3 bucket |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,19 +1,20 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
-| template | ~> 2.0 |
+| aws | >= 2.0 |
+| template | >= 2.0 |
 
 ## Inputs
 
@@ -102,3 +103,4 @@
 | s3\_bucket\_arn | ARN of S3 bucket |
 | s3\_bucket\_domain\_name | Domain of S3 bucket |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -364,7 +364,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.8.0"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.9.0"
   enabled          = var.enabled && (var.parent_zone_id != "" || var.parent_zone_name != "") ? true : false
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id

--- a/main.tf
+++ b/main.tf
@@ -156,7 +156,7 @@ resource "aws_s3_bucket" "origin" {
 }
 
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.13.1"
+  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.14.0"
   enabled                  = var.logging_enabled
   namespace                = var.namespace
   environment              = var.environment

--- a/main.tf
+++ b/main.tf
@@ -364,7 +364,7 @@ resource "aws_cloudfront_distribution" "default" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.9.0"
+  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.8.2"
   enabled          = var.enabled && (var.parent_zone_id != "" || var.parent_zone_name != "") ? true : false
   aliases          = var.aliases
   parent_zone_id   = var.parent_zone_id

--- a/main.tf
+++ b/main.tf
@@ -102,16 +102,12 @@ resource "aws_s3_bucket_policy" "default" {
   policy = data.template_file.default.rendered
 }
 
-data "aws_region" "current" {
-}
-
 resource "aws_s3_bucket" "origin" {
   count         = local.using_existing_origin ? 0 : 1
   bucket        = module.origin_label.id
   acl           = "private"
   tags          = module.origin_label.tags
   force_destroy = var.origin_force_destroy
-  region        = data.aws_region.current.name
 
   dynamic "server_side_encryption_configuration" {
     for_each = var.encryption_enabled ? ["true"] : []

--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,9 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.0"
-    local    = "~> 1.2"
-    null     = "~> 2.0"
+    aws      = ">= 2.0"
+    template = ">= 2.0"
+    local    = ">= 1.2"
+    null     = ">= 2.0"
   }
 }


### PR DESCRIPTION
## what
set minimum versions for providers without pinning to a specific major version



## why
the current method makes it very difficult to maintain or upgrade consistent provider versions within a project



## references
https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions



