### PR TITLE
add option for aws_s3_bucket_public_access_block for origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Available targets:
 | aliases | List of FQDN's - Used to set the Alternate Domain Names (CNAMEs) setting on Cloudfront | `list(string)` | `[]` | no |
 | allowed\_methods | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) for AWS CloudFront | `list(string)` | <pre>[<br>  "DELETE",<br>  "GET",<br>  "HEAD",<br>  "OPTIONS",<br>  "PATCH",<br>  "POST",<br>  "PUT"<br>]</pre> | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| block\_origin\_public\_access\_enabled | When set to 'true' the s3 origin bucket will have public access block enabled | `bool` | `false` | no |
 | bucket\_domain\_format | Format of bucket domain name | `string` | `"%s.s3.amazonaws.com"` | no |
 | cached\_methods | List of cached methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br>  "GET",<br>  "HEAD"<br>]</pre> | no |
 | cloudfront\_origin\_access\_identity\_iam\_arn | Existing cloudfront origin access identity iam arn that is supplied in the s3 bucket policy | `string` | `""` | no |
@@ -339,7 +340,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,6 +26,7 @@
 | aliases | List of FQDN's - Used to set the Alternate Domain Names (CNAMEs) setting on Cloudfront | `list(string)` | `[]` | no |
 | allowed\_methods | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) for AWS CloudFront | `list(string)` | <pre>[<br>  "DELETE",<br>  "GET",<br>  "HEAD",<br>  "OPTIONS",<br>  "PATCH",<br>  "POST",<br>  "PUT"<br>]</pre> | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
+| block\_origin\_public\_access\_enabled | When set to 'true' the s3 origin bucket will have public access block enabled | `bool` | `false` | no |
 | bucket\_domain\_format | Format of bucket domain name | `string` | `"%s.s3.amazonaws.com"` | no |
 | cached\_methods | List of cached methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br>  "GET",<br>  "HEAD"<br>]</pre> | no |
 | cloudfront\_origin\_access\_identity\_iam\_arn | Existing cloudfront origin access identity iam arn that is supplied in the s3 bucket policy | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -146,6 +146,15 @@ resource "aws_s3_bucket" "origin" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "origin" {
+  count                   = ! local.using_existing_origin && var.block_origin_public_access_enabled ? 1 : 0
+  bucket                  = local.bucket
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 module "logs" {
   source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.15.0"
   enabled                  = var.logging_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -429,3 +429,9 @@ variable "origin_ssl_protocols" {
   default     = ["TLSv1", "TLSv1.1", "TLSv1.2"]
   description = "The SSL/TLS protocols that you want CloudFront to use when communicating with your origin over HTTPS."
 }
+
+variable "block_origin_public_access_enabled" {
+  type        = bool
+  default     = false
+  description = "When set to 'true' the s3 origin bucket will have public access block enabled"
+}


### PR DESCRIPTION
## what
* This change allows you to add a `aws_s3_bucket_public_access_block`
resource for the origin s3 bucket.

## why
* On "Amazon S3 Preventative Security Best Practices" it is recommended
to use Amazon S3 block public access.

## references
* https://docs.aws.amazon.com/AmazonS3/latest/dev/security-best-practices.html
