### PR TITLE
mfa_delete removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ Available targets:
 | log\_standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier | `number` | `30` | no |
 | logging\_enabled | When true, access logs will be sent to a newly created s3 bucket | `bool` | `true` | no |
 | max\_ttl | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `31536000` | no |
-| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | min\_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | `number` | `0` | no |
 | minimum\_protocol\_version | Cloudfront TLS minimum protocol version | `string` | `"TLSv1"` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -68,7 +68,6 @@
 | log\_standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier | `number` | `30` | no |
 | logging\_enabled | When true, access logs will be sent to a newly created s3 bucket | `bool` | `true` | no |
 | max\_ttl | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `31536000` | no |
-| mfa\_delete | A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 ) | `bool` | `true` | no |
 | min\_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | `number` | `0` | no |
 | minimum\_protocol\_version | Cloudfront TLS minimum protocol version | `string` | `"TLSv1"` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -7,5 +7,3 @@ stage = "test"
 name = "cloudfront-s3-cdn"
 
 parent_zone_name = "testing.cloudposse.co"
-
-mfa_delete = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,7 +13,6 @@ module "cloudfront_s3_cdn" {
   cors_allowed_methods     = ["GET", "HEAD", "PUT"]
   cors_allowed_origins     = ["*.cloudposse.com"]
   cors_expose_headers      = ["ETag"]
-  mfa_delete               = var.mfa_delete
 }
 
 resource "aws_s3_bucket_object" "index" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -5,8 +5,3 @@ variable "region" {
 variable "parent_zone_name" {
   type = string
 }
-
-variable "mfa_delete" {
-  type        = bool
-  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-}

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ data "template_file" "default" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  count  = !local.using_existing_origin || var.override_origin_bucket_policy ? 1 : 0
+  count  = ! local.using_existing_origin || var.override_origin_bucket_policy ? 1 : 0
   bucket = local.bucket
   policy = data.template_file.default.rendered
 }
@@ -155,7 +155,7 @@ resource "aws_s3_bucket" "origin" {
 }
 
 resource "aws_s3_bucket_public_access_block" "origin" {
-  count                   = !local.using_existing_origin && var.block_origin_public_access_enabled ? 1 : 0
+  count                   = ! local.using_existing_origin && var.block_origin_public_access_enabled ? 1 : 0
   bucket                  = local.bucket
   block_public_acls       = true
   block_public_policy     = true
@@ -226,7 +226,7 @@ resource "aws_cloudfront_distribution" "default" {
     origin_path = var.origin_path
 
     dynamic "s3_origin_config" {
-      for_each = !var.website_enabled ? [1] : []
+      for_each = ! var.website_enabled ? [1] : []
       content {
         origin_access_identity = local.using_existing_cloudfront_origin ? var.cloudfront_origin_access_identity_path : join("", aws_cloudfront_origin_access_identity.default.*.cloudfront_access_identity_path)
       }

--- a/variables.tf
+++ b/variables.tf
@@ -441,9 +441,3 @@ variable "access_log_bucket_name" {
   default     = ""
   description = "Name of the S3 bucket where s3 access log will be sent to"
 }
-
-variable "mfa_delete" {
-  type        = bool
-  description = "A boolean that indicates that versions of S3 objects can only be deleted with MFA. ( Terraform cannot apply changes of this value; https://github.com/terraform-providers/terraform-provider-aws/issues/629 )"
-  default     = true
-}


### PR DESCRIPTION
## what
* `mfa_delete` removed
* Bridgecrew check `Ensure S3 bucket has MFA delete enabled` skipped

## why
* Because terraform doesn't support this argument to be toggled (https://github.com/hashicorp/terraform-provider-aws/issues/629).
* To satisfy Bridgecrew compliance scan

## references
* https://github.com/hashicorp/terraform-provider-aws/issues/629

