### PR TITLE
feat: make logbucket versioning optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Available targets:
 | log\_include\_cookies | Include cookies in access logs | `bool` | `false` | no |
 | log\_prefix | Path of logs in S3 bucket | `string` | `""` | no |
 | log\_standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier | `number` | `30` | no |
+| log\_versioning\_enabled | When true, the access logs bucket will be versioned | `bool` | `false` | no |
 | logging\_enabled | When true, access logs will be sent to a newly created s3 bucket | `bool` | `true` | no |
 | max\_ttl | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `31536000` | no |
 | min\_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | `number` | `0` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -66,6 +66,7 @@
 | log\_include\_cookies | Include cookies in access logs | `bool` | `false` | no |
 | log\_prefix | Path of logs in S3 bucket | `string` | `""` | no |
 | log\_standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier | `number` | `30` | no |
+| log\_versioning\_enabled | When true, the access logs bucket will be versioned | `bool` | `false` | no |
 | logging\_enabled | When true, access logs will be sent to a newly created s3 bucket | `bool` | `true` | no |
 | max\_ttl | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `31536000` | no |
 | min\_ttl | Minimum amount of time that you want objects to stay in CloudFront caches | `number` | `0` | no |

--- a/main.tf
+++ b/main.tf
@@ -173,6 +173,7 @@ module "logs" {
   glacier_transition_days  = var.log_glacier_transition_days
   expiration_days          = var.log_expiration_days
   force_destroy            = var.origin_force_destroy
+  versioning_enabled       = var.log_versioning_enabled
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,12 @@ variable "logging_enabled" {
   description = "When true, access logs will be sent to a newly created s3 bucket"
 }
 
+variable "log_versioning_enabled" {
+  type        = bool
+  default     = false
+  description = "When true, the access logs bucket will be versioned"
+}
+
 variable "log_include_cookies" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* Disable versioning by-default for the logging bucket. This value is now user-configurable.

## why
* In [terraform-aws-s3-log-storage 0.18.0](https://github.com/cloudposse/terraform-aws-s3-log-storage/releases/tag/0.18.0) versioning was added as a variable, but not added to the s3-cdn module.
* Versioning on the logging bucket does not make much sense, but can be turned on if desired.

## references
* [terraform-aws-s3-log-storage 0.18.0](https://github.com/cloudposse/terraform-aws-s3-log-storage/releases/tag/0.18.0)

