### PR TITLE
Serialise origin bucket modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,28 @@ Available targets:
 | aws | >= 2.0 |
 | template | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| dns | cloudposse/route53-alias/aws | 0.12.0 |
+| logs | cloudposse/s3-log-storage/aws | 0.20.0 |
+| origin_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) |
+| [aws_cloudfront_origin_access_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
+| [aws_s3_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) |
+| [template_file](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -271,7 +293,6 @@ Available targets:
 | s3\_bucket | Name of S3 bucket |
 | s3\_bucket\_arn | ARN of S3 bucket |
 | s3\_bucket\_domain\_name | Domain of S3 bucket |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,6 +14,28 @@
 | aws | >= 2.0 |
 | template | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| dns | cloudposse/route53-alias/aws | 0.12.0 |
+| logs | cloudposse/s3-log-storage/aws | 0.20.0 |
+| origin_label | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) |
+| [aws_cloudfront_origin_access_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
+| [aws_s3_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) |
+| [template_file](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -115,5 +137,4 @@
 | s3\_bucket | Name of S3 bucket |
 | s3\_bucket\_arn | ARN of S3 bucket |
 | s3\_bucket\_domain\_name | Domain of S3 bucket |
-
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ data "template_file" "default" {
 
 resource "aws_s3_bucket_policy" "default" {
   count  = ! local.using_existing_origin || var.override_origin_bucket_policy ? 1 : 0
-  bucket = aws_s3_bucket.origin.bucket
+  bucket = join("", aws_s3_bucket.origin.*.bucket)
   policy = data.template_file.default.rendered
 }
 

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ data "template_file" "default" {
 
 resource "aws_s3_bucket_policy" "default" {
   count  = ! local.using_existing_origin || var.override_origin_bucket_policy ? 1 : 0
-  bucket = local.bucket
+  bucket = aws_s3_bucket.origin.bucket
   policy = data.template_file.default.rendered
 }
 
@@ -161,6 +161,10 @@ resource "aws_s3_bucket_public_access_block" "origin" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+
+  # Don't ty and modify this bucket in two ways at the same time, S3 API will
+  # complain.
+  depends_on = [ aws_s3_bucket_policy.default ]
 }
 
 module "logs" {

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ resource "aws_s3_bucket_public_access_block" "origin" {
 
   # Don't ty and modify this bucket in two ways at the same time, S3 API will
   # complain.
-  depends_on = [ aws_s3_bucket_policy.default ]
+  depends_on = [aws_s3_bucket_policy.default]
 }
 
 module "logs" {


### PR DESCRIPTION
You can't modify an S3 bucket's policy & public access block at the same
time, AWS API will complain:

OperationAborted: A conflicting conditional operation is currently in progress against this resource

This error can appear during both deploy and destroy for the module.

Serialise operations to the origin bucket so we don't run into this
error. The suggested fix is from

https://github.com/hashicorp/terraform-provider-aws/issues/7628