### PR TITLE
Use `website_endpoint` instead of `bucket_regional_domain_name`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,8 +181,10 @@ locals {
       concat([var.origin_bucket], concat([""], aws_s3_bucket.origin.*.id))
     )
   )
+
   bucket_website_domain_name  = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].website_endpoint, "") : try(aws_s3_bucket.origin[0].website_endpoint, "")
   bucket_regional_domain_name = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].bucket_regional_domain_name, "") : try(aws_s3_bucket.origin[0].bucket_regional_domain_name, "")
+  bucket_domain_name          = var.website_enabled ? local.bucket_website_domain_name : local.bucket_regional_domain_name
 }
 
 resource "aws_cloudfront_distribution" "default" {
@@ -206,7 +208,7 @@ resource "aws_cloudfront_distribution" "default" {
   aliases = var.acm_certificate_arn != "" ? var.aliases : []
 
   origin {
-    domain_name = var.website_enabled ? local.bucket_website_domain_name : local.bucket_regional_domain_name
+    domain_name = local.bucket_domain_name
     origin_id   = module.this.id
     origin_path = var.origin_path
 

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ locals {
       concat([var.origin_bucket], concat([""], aws_s3_bucket.origin.*.id))
     )
   )
-  bucket_domain_name = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].bucket_regional_domain_name, "") : try(aws_s3_bucket.origin[0].bucket_regional_domain_name, "")
+  bucket_domain_name = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].website_endpoint, "") : try(aws_s3_bucket.origin[0].website_endpoint, "")
 }
 
 resource "aws_cloudfront_distribution" "default" {

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,8 @@ locals {
       concat([var.origin_bucket], concat([""], aws_s3_bucket.origin.*.id))
     )
   )
-  bucket_domain_name = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].website_endpoint, "") : try(aws_s3_bucket.origin[0].website_endpoint, "")
+  bucket_website_domain_name = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].website_endpoint, "") : try(aws_s3_bucket.origin[0].website_endpoint, "")
+  bucket_regional_domain_name = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].bucket_regional_domain_name, "") : try(aws_s3_bucket.origin[0].bucket_regional_domain_name, "")
 }
 
 resource "aws_cloudfront_distribution" "default" {
@@ -205,7 +206,7 @@ resource "aws_cloudfront_distribution" "default" {
   aliases = var.acm_certificate_arn != "" ? var.aliases : []
 
   origin {
-    domain_name = local.bucket_domain_name
+    domain_name = var.website_enabled ? local.bucket_website_domain_name : local.bucket_regional_domain_name
     origin_id   = module.this.id
     origin_path = var.origin_path
 

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ locals {
       concat([var.origin_bucket], concat([""], aws_s3_bucket.origin.*.id))
     )
   )
-  bucket_website_domain_name = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].website_endpoint, "") : try(aws_s3_bucket.origin[0].website_endpoint, "")
+  bucket_website_domain_name  = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].website_endpoint, "") : try(aws_s3_bucket.origin[0].website_endpoint, "")
   bucket_regional_domain_name = local.using_existing_origin ? try(data.aws_s3_bucket.selected[0].bucket_regional_domain_name, "") : try(aws_s3_bucket.origin[0].bucket_regional_domain_name, "")
 }
 


### PR DESCRIPTION
## what
* Uses the bucket `website_endpoint` instead of the `bucket_regional_domain_name`
* The `bucket_regional_domain_name` is incorrectly documented in the hashicorp [aws_cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) docs

## why
* Fixes an issue introduced in a recent PR which drops the `-website` portion of the domain

## references
* Closes https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/148
* Fixes previous PR https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/143/files#r604661084

@syphernl has confirmed that this fixes his issue by using the feature branch as a source.