### PR TITLE
Docs: Fix snippet passing incorrect variable name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ module "cdn" {
   dns_alias_enabled = true
   parent_zone_name  = "cloudposse.com"
 
-  deployment_arns = {
+  deployment_principal_arns = {
     "arn:aws:s3:::principal1" = ["/prefix1", "/prefix2"]
     "arn:aws:s3:::principal2" = [""]
   }

--- a/README.yaml
+++ b/README.yaml
@@ -79,7 +79,7 @@ usage: |-
     dns_alias_enabled = true
     parent_zone_name  = "cloudposse.com"
 
-    deployment_arns = {
+    deployment_principal_arns = {
       "arn:aws:s3:::principal1" = ["/prefix1", "/prefix2"]
       "arn:aws:s3:::principal2" = [""]
     }


### PR DESCRIPTION
## what
* Fix snippet passing in `deployment_arns` instead of `deployment_principal_arns`.

## why
* The snippet in the README is not accurate.

## references
* #160 

