### PR TITLE
Use bucket.website_endpoint instead of bucket.website_domain

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
   ) : ""
 
   bucket             = local.origin_bucket.bucket
-  bucket_domain_name = var.website_enabled ? local.origin_bucket.website_domain : local.origin_bucket.bucket_regional_domain_name
+  bucket_domain_name = var.website_enabled ? local.origin_bucket.website_endpoint : local.origin_bucket.bucket_regional_domain_name
 
   override_origin_bucket_policy = local.enabled && var.override_origin_bucket_policy
 


### PR DESCRIPTION
## what
There is currently a bug introduced in version v0.64.0 which prevents CloudFront from connecting to the bucket. `bucket.website_domain = "s3-website-<region>.amazonaws.com"` (see AWS provider source code https://github.com/hashicorp/terraform-provider-aws/blob/ac06ced75cba0daf09fef2938752ad13cc6fff6e/aws/resource_aws_s3_bucket.go#L1747). In https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/blob/master/main.tf#L319 `local.bucket_domain_name` is used in CloudFront origin, but since it is  "s3-website.eu-central-1.amazonaws.com" (in our case) - CloudFront gets a redirect to https://aws.amazon.com/s3/ and nothing works...