### PR TITLE
Disable SSL-only policy if ACM certificate given

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -184,7 +184,7 @@ data "aws_iam_policy_document" "deployment" {
 }
 
 data "aws_iam_policy_document" "s3_ssl_only" {
-  count = var.allow_ssl_requests_only ? 1 : 0
+  count = var.allow_ssl_requests_only && var.acm_certificate_arn == "" ? 1 : 0
   statement {
     sid     = "ForceSSLOnlyAccess"
     effect  = "Deny"


### PR DESCRIPTION
## what
* Disables SSL-only requests restriction at S3 static-website settings when Cloudfront will handle TLS given an ACM certificate.

## why
* There is a conflict when setting up both CDN-level TLS and S3-level SSL, which makes S3 respond with a HTTP 403 error.

## references
* Closes #175


