### PR TITLE
Chore: Update `auto-release` (`release-drafter`) GHA workflow to latest distribution; fix Terratest

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,6 +17,7 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
+    - 'no-release'
   default: 'minor'
 
 categories:
@@ -46,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,24 @@ name: auto-release
 on:
   push:
     branches:
-    - master
+      - main
+      - master
+      - production
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    - uses: release-drafter/release-drafter@v5
-      with:
-        publish: true
-        prerelease: false
-        config-name: auto-release.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Get PR from merged commit to master
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
+          prerelease: false
+          config-name: auto-release.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/examples/complete/deployment.tf
+++ b/examples/complete/deployment.tf
@@ -8,18 +8,19 @@ locals {
 
   our_account_id            = local.enabled ? data.aws_caller_identity.current[0].account_id : ""
   our_role_arn_prefix       = "arn:aws:iam::${local.our_account_id}:role"
-  deployment_principal_arns = { for k, v in local.test_deployment_role_prefix_map : format("%v/%v", local.our_role_arn_prefix, k) => v }
+  role_names                = { for k, v in local.test_deployment_role_prefix_map : k => module.role_labels[k].id }
+  deployment_principal_arns = { for k, v in local.role_names: format("%v/%v", local.our_role_arn_prefix, v) => local.test_deployment_role_prefix_map[k] }
 }
 
 data "aws_caller_identity" "current" {
   count = local.enabled ? 1 : 0
 }
 
-
-module "statement_ids" {
+# The following instantiations of null-label require Terraform >= 0.13.0
+module "sid_labels" {
   for_each = local.test_deployment_role_prefix_map
   source   = "cloudposse/label/null"
-  version  = "0.24.1" # requires Terraform >= 0.13.0
+  version  = "0.25.0"
 
   attributes          = split("-", each.key)
   delimiter           = ""
@@ -29,11 +30,21 @@ module "statement_ids" {
   context = module.this.context
 }
 
-data "aws_iam_policy_document" "assume_role" {
+module "role_labels" {
   for_each = local.test_deployment_role_prefix_map
+  source   = "cloudposse/label/null"
+  version  = "0.25.0"
+
+  attributes = concat(split("-", each.key), module.this.attributes)
+
+  context = module.this.context
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  for_each = module.sid_labels
 
   statement {
-    sid = "Enable${module.statement_ids[each.key].id}"
+    sid = "Enable${each.value.id}"
     actions = [
       "sts:AssumeRole",
       "sts:TagSession"
@@ -49,9 +60,9 @@ data "aws_iam_policy_document" "assume_role" {
 
 
 resource "aws_iam_role" "test_role" {
-  for_each = local.test_deployment_role_prefix_map
+  for_each = module.role_labels
 
-  name = each.key
+  name = module.role_labels[each.key].id
 
   assume_role_policy = data.aws_iam_policy_document.assume_role[each.key].json
 }

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -16,7 +16,7 @@ init:
 ## Run tests
 test: init
 	go mod download
-	go test -v -timeout 20m -parallel 2 -run TestExamplesComplete
+	go test -v -timeout 30m -parallel 2 -run TestExamplesComplete
 
 ## Run tests in docker container
 docker/test:


### PR DESCRIPTION
## what
- Update auto-release (release-drafter) GHA workflow to latest distribution from build-harness.
- Fix Terratest by ensuring IAM roles created by examples/complete are unique for each run (also increase test timeout).

## why
- The latest distribution of the `auto-release` GHA workflow from https://github.com/cloudposse/build-harness allows merged PRs to be accumulated in a draft release when the `no-release` label is used. This allows PRs to be consolidated rather than each given their own release — as renovatebot will cause a rippling series of module updates across all repositories that use this module, and all repositories that use those modules, etc.
- This is a subset of `make github/init`, which will update all GHA-related files to the latest build-harness distribution. However, changing CODEOWNERS will require admin approval and this is a blocker.
- Terratest was failing because `examples/complete` was creating IAM roles whose names did not make the use of `module.this.attributes` (which contains a random seed in each run). Also, the test timeout was not sufficiently long to complete all tests.

## references
* https://github.com/cloudposse/build-harness/pull/296
* #201 
