### PR TITLE
Fix: Do Not Hardcode AWS Partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Available targets:
 | [aws_iam_policy_document.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_ssl_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_website_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_s3_bucket.cf_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -38,6 +38,7 @@
 | [aws_iam_policy_document.s3_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_ssl_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_website_origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_s3_bucket.cf_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 

--- a/examples/complete/deployment.tf
+++ b/examples/complete/deployment.tf
@@ -7,7 +7,7 @@ locals {
   } : {}
 
   our_account_id            = local.enabled ? data.aws_caller_identity.current[0].account_id : ""
-  our_role_arn_prefix       = "arn:aws:iam::${local.our_account_id}:role"
+  our_role_arn_prefix       = "arn:${join("", data.aws_partition.current.*.partition)}:iam::${local.our_account_id}:role"
   role_names                = { for k, v in local.test_deployment_role_prefix_map : k => module.role_labels[k].id }
   deployment_principal_arns = { for k, v in local.role_names : format("%v/%v", local.our_role_arn_prefix, v) => local.test_deployment_role_prefix_map[k] }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -7,6 +7,10 @@ locals {
   additional_origin_groups = concat(local.additional_custom_origin_groups, local.additional_s3_origin_groups)
 }
 
+data "aws_partition" "current" {
+  count = local.enabled ? 1 : 0
+}
+
 data "aws_iam_policy_document" "document" {
   count = local.enabled ? 1 : 0
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "document" {
 
     actions = ["s3:GetObject"]
     resources = [
-      "arn:aws:s3:::$${bucket_name}$${origin_path}testprefix/*"
+      "arn:${join("", data.aws_partition.current.*.partition)}:s3:::$${bucket_name}$${origin_path}testprefix/*"
     ]
 
     principals {

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,10 @@ locals {
   "$${cloudfront_origin_access_identity_iam_arn}", local.cf_access.arn)
 }
 
+data "aws_partition" "current" {
+  count = local.enabled ? 1 : 0
+}
+
 module "origin_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"
@@ -117,7 +121,7 @@ data "aws_iam_policy_document" "s3_origin" {
     sid = "S3GetObjectForCloudFront"
 
     actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${local.bucket}${local.origin_path}*"]
+    resources = ["arn:${join("", data.aws_partition.current.*.partition)}:s3:::${local.bucket}${local.origin_path}*"]
 
     principals {
       type        = "AWS"
@@ -129,7 +133,7 @@ data "aws_iam_policy_document" "s3_origin" {
     sid = "S3ListBucketForCloudFront"
 
     actions   = ["s3:ListBucket"]
-    resources = ["arn:aws:s3:::${local.bucket}"]
+    resources = ["arn:${join("", data.aws_partition.current.*.partition)}:s3:::${local.bucket}"]
 
     principals {
       type        = "AWS"
@@ -147,7 +151,7 @@ data "aws_iam_policy_document" "s3_website_origin" {
     sid = "S3GetObjectForCloudFront"
 
     actions   = ["s3:GetObject"]
-    resources = ["arn:aws:s3:::${local.bucket}${local.origin_path}*"]
+    resources = ["arn:${join("", data.aws_partition.current.*.partition)}:s3:::${local.bucket}${local.origin_path}*"]
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
## what
* Do not hardcode AWS partition.

## why
* Adds support for partitions other than `aws`, such as `aws-us-gov`.

## references
* closes #200 

