### PR TITLE
fix: set viewer_certificate.ssl_support_method to a non-empty value

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -439,7 +439,7 @@ resource "aws_cloudfront_distribution" "default" {
 
   viewer_certificate {
     acm_certificate_arn            = var.acm_certificate_arn
-    ssl_support_method             = local.use_default_acm_certificate ? "" : "sni-only"
+    ssl_support_method             = "sni-only"
     minimum_protocol_version       = local.minimum_protocol_version
     cloudfront_default_certificate = local.use_default_acm_certificate
   }


### PR DESCRIPTION
## what
* Sets the `viewer_certificate.ssl_support_method` to a non-empty value

## why
* Since [AWS Provider 3.71.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.71.0) the `viewer_certificate.ssl_support_method` is being validated on plan-time and can no longer be an empty string but must be `sni-only` or `vip` (of which the latter incurs costs)

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#ssl_support_method

