### PR TITLE
Added new response_headers_policy_id argument for a block with Custom behavior

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -549,10 +549,11 @@ resource "aws_cloudfront_distribution" "default" {
         }
       }
 
-      viewer_protocol_policy = ordered_cache_behavior.value.viewer_protocol_policy
-      default_ttl            = ordered_cache_behavior.value.default_ttl
-      min_ttl                = ordered_cache_behavior.value.min_ttl
-      max_ttl                = ordered_cache_behavior.value.max_ttl
+      viewer_protocol_policy     = ordered_cache_behavior.value.viewer_protocol_policy
+      default_ttl                = ordered_cache_behavior.value.default_ttl
+      min_ttl                    = ordered_cache_behavior.value.min_ttl
+      max_ttl                    = ordered_cache_behavior.value.max_ttl
+      response_headers_policy_id = try(ordered_cache_behavior.value.response_headers_policy_id, null)
 
       dynamic "lambda_function_association" {
         for_each = ordered_cache_behavior.value.lambda_function_association

--- a/variables.tf
+++ b/variables.tf
@@ -388,10 +388,11 @@ variable "ordered_cache" {
     cache_policy_id          = string
     origin_request_policy_id = string
 
-    viewer_protocol_policy = string
-    min_ttl                = number
-    default_ttl            = number
-    max_ttl                = number
+    viewer_protocol_policy     = string
+    min_ttl                    = number
+    default_ttl                = number
+    max_ttl                    = number
+    response_headers_policy_id = string
 
     forward_query_string              = bool
     forward_header_values             = list(string)


### PR DESCRIPTION
[main.tf, variables.tf] 

## what
* Added new response_headers_policy_id argument for a block with Custom behavior

## why
* They just forgot about the cusom block `ordered_cache_behavior`

## references
* https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/192
