### PR TITLE
Ability to specify source directory for Lambda@Edge submodule

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+---
+name: Bug report
+description: Create a report to help us improve
+labels: ["bug"]
+assignees: [""]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Found a bug?
+        
+        Please checkout our [Slack Community](https://slack.cloudposse.com)
+        or visit our [Slack Archive](https://archive.sweetops.com/).
+
+        [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+  - type: textarea
+    id: concise-description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: What is the bug about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: How do we reproduce it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots or logs to help explain.
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Anything that will help us triage the bug.
+      placeholder: |
+        - OS: [e.g. Linux, OSX, WSL, etc]
+        - Version [e.g. 10.15]
+        - Module version
+        - Terraform version
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+---
+name: Feature Request
+description: Suggest an idea for this project
+labels: ["feature request"]
+assignees: [""]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question?
+        
+        Please checkout our [Slack Community](https://slack.cloudposse.com)
+        or visit our [Slack Archive](https://archive.sweetops.com/).
+
+        [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+
+  - type: textarea
+    id: concise-description
+    attributes:
+      label: Describe the Feature
+      description: A clear and concise description of what the feature is.
+      placeholder: What is the feature about?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected.
+      placeholder: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Is your feature request related to a problem/challenge you are trying
+        to solve?
+        
+        Please provide some additional context of why this feature or
+        capability will be valuable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: ideal-solution
+    attributes:
+      label: Describe Ideal Solution
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Explain alternative solutions or features considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,21 @@
 ## what
-* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
-* Use bullet points to be concise and to the point.
+
+<!--
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+-->
 
 ## why
-* Provide the justifications for the changes (e.g. business case). 
-* Describe why these changes were made (e.g. why do these commits fix the problem?)
-* Use bullet points to be concise and to the point.
+
+<!--
+- Provide the justifications for the changes (e.g. business case). 
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+-->
 
 ## references
-* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
-* Use `closes #123`, if this PR closes a GitHub issue `#123`
 
+<!--
+- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
+- Use `closes #123`, if this PR closes a GitHub issue `#123`
+-->

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request::true"
+            echo "create_pull_request=true" >> "$GITHUB_OUTPUT"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
@@ -37,7 +37,7 @@ jobs:
       if: steps.update.outputs.create_pull_request == 'true'
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -19,7 +19,7 @@ jobs:
       if: github.event.pull_request.state == 'open'
       name: Privileged Checkout
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         # Check out the PR commit, not the merge commit
         # Use `ref` instead of `sha` to enable pushing back to `ref`
@@ -30,7 +30,7 @@ jobs:
       if: github.event.pull_request.state == 'open'
       shell: bash
       env:
-        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        GITHUB_TOKEN: "${{ secrets.REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch
@@ -54,10 +54,10 @@ jobs:
           [[ $SENDER ==  "cloudpossebot" ]] || git push
           # Set status to fail, because the push should trigger another status check,
           # and we use success to indicate the checks are finished.
-          printf "::set-output name=%s::%s\n" "changed" "true"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
           exit 1
         else
-          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           echo "No changes detected"
         fi
 
@@ -75,7 +75,7 @@ jobs:
         contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
         && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         repository: cloudposse/actions
         event-type: test-command
         client-payload: |-

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        echo "defaultBranch=${default_branch}" >> "$GITHUB_OUTPUT"
         printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
     - name: Update readme
@@ -52,7 +52,7 @@ jobs:
       # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
       uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
-        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
         commit-message: Update README.md and docs
         title: Update README.md and docs
         body: |-

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
-          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          github_token: ${{ secrets.REPO_ACCESS_TOKEN }}
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         with:
@@ -23,4 +23,4 @@ jobs:
           prerelease: false
           config-name: auto-release.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -11,7 +11,7 @@ jobs:
       - name: "Handle common commands"
         uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
@@ -26,7 +26,7 @@ jobs:
       - name: "Run tests"
         uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
-          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: test

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -21,7 +21,7 @@ jobs:
         checks: "syntax,owners,duppatterns"
         owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
-        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+        github_access_token: "${{ secrets.REPO_ACCESS_TOKEN }}"
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |

--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |

--- a/examples/complete/lambda-at-edge.tf
+++ b/examples/complete/lambda-at-edge.tf
@@ -35,6 +35,14 @@ module "lambda_at_edge" {
       event_type   = "viewer-request"
       include_body = false
     },
+    # Add custom header to the response
+    viewer_response = {
+      source_dir   = "lib"
+      runtime      = "nodejs12.x"
+      handler      = "index.handler"
+      event_type   = "viewer-response"
+      include_body = false
+    },
     # Add security headers to the request from CF to the origin
     origin_request = {
       source = [{

--- a/examples/complete/lib/index.js
+++ b/examples/complete/lib/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+exports.handler = (event, context, callback) => {
+    const response = event.Records[0].cf.response;
+    const headers = response.headers;
+
+    // Add a custom header to the response
+    headers['x-custom-header'] = [{ key: 'X-Custom-Header', value: 'My custom value' }];
+
+    callback(null, response);
+};

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
   # Encapsulate logic here so that it is not lost/scattered among the configuration
   website_enabled           = local.enabled && var.website_enabled
   website_password_enabled  = local.website_enabled && var.s3_website_password_enabled
-  s3_origin_enabled         = local.enabled && ! var.website_enabled
+  s3_origin_enabled         = local.enabled && !var.website_enabled
   create_s3_origin_bucket   = local.enabled && var.origin_bucket == null
   s3_access_logging_enabled = local.enabled && (var.s3_access_logging_enabled == null ? length(var.s3_access_log_bucket_name) > 0 : var.s3_access_logging_enabled)
   create_cf_log_bucket      = local.cloudfront_access_logging_enabled && local.cloudfront_access_log_create_bucket
@@ -52,7 +52,7 @@ locals {
 
   override_origin_bucket_policy = local.enabled && var.override_origin_bucket_policy
 
-  lookup_cf_log_bucket = local.cloudfront_access_logging_enabled && ! local.cloudfront_access_log_create_bucket
+  lookup_cf_log_bucket = local.cloudfront_access_logging_enabled && !local.cloudfront_access_log_create_bucket
   cf_log_bucket_domain = local.cloudfront_access_logging_enabled ? (
     local.lookup_cf_log_bucket ? data.aws_s3_bucket.cf_logs[0].bucket_domain_name : module.logs.bucket_domain_name
   ) : ""
@@ -418,7 +418,7 @@ resource "aws_cloudfront_distribution" "default" {
     origin_path = var.origin_path
 
     dynamic "s3_origin_config" {
-      for_each = ! var.website_enabled ? [1] : []
+      for_each = !var.website_enabled ? [1] : []
       content {
         origin_access_identity = local.cf_access.path
       }

--- a/modules/lambda@edge/outputs.tf
+++ b/modules/lambda@edge/outputs.tf
@@ -11,7 +11,7 @@ output "lambda_function_association" {
 
 output "lambda_functions" {
   description = "The Lambda@Edge functions"
-  value       = {
+  value = {
     for key, value in local.functions : key => {
       arn           = aws_lambda_function.default[key].arn,
       qualified_arn = aws_lambda_function.default[key].qualified_arn,

--- a/modules/lambda@edge/outputs.tf
+++ b/modules/lambda@edge/outputs.tf
@@ -8,3 +8,14 @@ output "lambda_function_association" {
     }
   ]
 }
+
+output "lambda_functions" {
+  description = "The Lambda@Edge functions"
+  value       = {
+    for key, value in local.functions : key => {
+      arn           = aws_lambda_function.default[key].arn,
+      qualified_arn = aws_lambda_function.default[key].qualified_arn,
+      role_arn      = aws_lambda_function.default[key].role
+    }
+  }
+}

--- a/modules/lambda@edge/package.tf
+++ b/modules/lambda@edge/package.tf
@@ -2,7 +2,7 @@ data "archive_file" "lambda_zip" {
   for_each = local.functions
 
   dynamic "source" {
-    for_each = can(var.functions[each.key].source) ? each.value.source : []
+    for_each = can(var.functions[each.key].source) && length(var.functions[each.key].source) > 0 ? each.value.source : []
 
     content {
       content  = source.value.content

--- a/modules/lambda@edge/package.tf
+++ b/modules/lambda@edge/package.tf
@@ -1,14 +1,18 @@
 data "archive_file" "lambda_zip" {
   for_each = local.functions
 
-  dynamic "source" {
-    for_each = each.value.source
+#  dynamic "source" {
+#    for_each = each.value.source
+#
+#    content {
+#      content  = source.value.content
+#      filename = source.value.filename
+#    }
+#  }
 
-    content {
-      content  = source.value.content
-      filename = source.value.filename
-    }
-  }
+  source = can(var.functions[each.key].source_dir) ? null : flatten([
+    for source in each.value.source : source.content
+  ])
 
   source_dir       = can(var.functions[each.key].source_dir) ? each.value.source_dir : null
   type             = "zip"

--- a/modules/lambda@edge/package.tf
+++ b/modules/lambda@edge/package.tf
@@ -1,18 +1,14 @@
 data "archive_file" "lambda_zip" {
   for_each = local.functions
 
-#  dynamic "source" {
-#    for_each = each.value.source
-#
-#    content {
-#      content  = source.value.content
-#      filename = source.value.filename
-#    }
-#  }
+  dynamic "source" {
+    for_each = each.value.source
 
-  source = can(var.functions[each.key].source_dir) ? null : flatten([
-    for source in each.value.source : source.content
-  ])
+    content {
+      content  = source.value.content
+      filename = source.value.filename
+    }
+  }
 
   source_dir       = can(var.functions[each.key].source_dir) ? each.value.source_dir : null
   type             = "zip"

--- a/modules/lambda@edge/package.tf
+++ b/modules/lambda@edge/package.tf
@@ -2,7 +2,7 @@ data "archive_file" "lambda_zip" {
   for_each = local.functions
 
   dynamic "source" {
-    for_each = coalesce(var.functions[each.key].source, [])
+    for_each = coalesce(each.value.source, [])
 
     content {
       content  = source.value.content
@@ -10,7 +10,7 @@ data "archive_file" "lambda_zip" {
     }
   }
 
-  source_dir       = can(var.functions[each.key].source_dir) ? each.value.source_dir : null
+  source_dir       = each.value.source_dir
   type             = "zip"
   output_file_mode = "0666"
   output_path      = "${path.module}/archives/${each.key}.zip"

--- a/modules/lambda@edge/package.tf
+++ b/modules/lambda@edge/package.tf
@@ -2,7 +2,7 @@ data "archive_file" "lambda_zip" {
   for_each = local.functions
 
   dynamic "source" {
-    for_each = each.value.source
+    for_each = can(var.functions[each.key].source) ? each.value.source : null
 
     content {
       content  = source.value.content

--- a/modules/lambda@edge/package.tf
+++ b/modules/lambda@edge/package.tf
@@ -10,6 +10,7 @@ data "archive_file" "lambda_zip" {
     }
   }
 
+  source_dir       = can(var.functions[each.key].source_dir) ? each.value.source_dir : null
   type             = "zip"
   output_file_mode = "0666"
   output_path      = "${path.module}/archives/${each.key}.zip"

--- a/modules/lambda@edge/package.tf
+++ b/modules/lambda@edge/package.tf
@@ -2,7 +2,7 @@ data "archive_file" "lambda_zip" {
   for_each = local.functions
 
   dynamic "source" {
-    for_each = can(var.functions[each.key].source) ? each.value.source : null
+    for_each = can(var.functions[each.key].source) ? each.value.source : []
 
     content {
       content  = source.value.content

--- a/modules/lambda@edge/package.tf
+++ b/modules/lambda@edge/package.tf
@@ -2,7 +2,7 @@ data "archive_file" "lambda_zip" {
   for_each = local.functions
 
   dynamic "source" {
-    for_each = can(var.functions[each.key].source) && length(var.functions[each.key].source) > 0 ? each.value.source : []
+    for_each = coalesce(var.functions[each.key].source, [])
 
     content {
       content  = source.value.content

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -31,10 +31,10 @@ variable "functions" {
   }))
 
   validation {
-    condition = (
-      (var.functions.source != null && var.functions.source_dir == null) ||
-      (var.functions.source == null && var.functions.source_dir != null)
-    )
+    condition = alltrue([
+      for f in var.functions :
+      ((f.source != null && f.source_dir == null) || (f.source == null && f.source_dir != null))
+    ])
     error_message = "Either 'source' or 'source_dir' field must be specified, but not both."
   }
 }

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -4,8 +4,12 @@ variable "functions" {
 
   The key of this map is the name label of the Lambda@Edge function.
 
+  Either `source` or `source_dir` must be specified. These variables are mutually exclusive.
+
   `source.filename` and `source.content` dictate the name and content of the files that will make up the Lambda function
   source, respectively.
+
+  `source_dir` contains path to whole directory that has to be archived.
 
   `runtime` and `handler` correspond to the attributes of the same name in the [lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function)
   resource.
@@ -15,11 +19,11 @@ variable "functions" {
   resource.
   EOT
   type = map(object({
-    source = list(object({
+    source = optional(list(object({
       filename = string
       content  = string
-    }))
-    source_dir   = string
+    })))
+    source_dir   = optional(string)
     runtime      = string
     handler      = string
     event_type   = string

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -33,7 +33,7 @@ variable "functions" {
   validation {
     condition = length([
       for k, v in var.functions :
-      k if (v.source != null && v.source_dir == null) || (v.source == null && v.source_dir != null)
+      k if(v.source != null && v.source_dir == null) || (v.source == null && v.source_dir != null)
     ]) == 1
     error_message = "Either 'source' or 'source_dir' field must be specified, but not both."
   }

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -31,10 +31,10 @@ variable "functions" {
   }))
 
   validation {
-    condition = alltrue([
-      for f in var.functions :
-      ((f.source != null && f.source_dir == null) || (f.source == null && f.source_dir != null))
-    ])
+    condition = length([
+      for k, v in var.functions :
+      k if (v.source != null && v.source_dir == null) || (v.source == null && v.source_dir != null)
+    ]) == 1
     error_message = "Either 'source' or 'source_dir' field must be specified, but not both."
   }
 }

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -31,10 +31,10 @@ variable "functions" {
   }))
 
   validation {
-    condition = length([
-      for k, v in var.functions :
-      k if(v.source != null && v.source_dir == null) || (v.source == null && v.source_dir != null)
-    ]) == 1
+    condition = alltrue([
+      for f in var.functions :
+      ((f.source != null && f.source_dir == null) || (f.source == null && f.source_dir != null))
+    ])
     error_message = "Either 'source' or 'source_dir' field must be specified, but not both."
   }
 }

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -29,6 +29,14 @@ variable "functions" {
     event_type   = string
     include_body = bool
   }))
+
+  validation {
+    condition = (
+      (var.functions.source != null && var.functions.source_dir == null) ||
+      (var.functions.source == null && var.functions.source_dir != null)
+    )
+    error_message = "Either 'source' or 'source_dir' field must be specified, but not both."
+  }
 }
 
 variable "destruction_delay" {

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -19,7 +19,7 @@ variable "functions" {
       filename = string
       content  = string
     }))
-    source_dir   = list(string)
+    source_dir   = string
     runtime      = string
     handler      = string
     event_type   = string

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -19,6 +19,7 @@ variable "functions" {
       filename = string
       content  = string
     }))
+    source_dir   = list(string)
     runtime      = string
     handler      = string
     event_type   = string

--- a/modules/lambda@edge/versions.tf
+++ b/modules/lambda@edge/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/modules/lambda@edge/versions.tf
+++ b/modules/lambda@edge/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what
* Ability to specify source directory for Lambda@Edge submodule

## why
* Currently, we can pass the list of files that will be archived and uploaded as Lambda sources. This is not an option if more advanced logic is used and a lot of files should be used.

**Example**

For example, we have the following file structure for lambda@edge submodule:

```
lambda_edge_example/
    lib/
        node_modules/
        index.js
        package.json
        package-lock.json
    context.tf
    main.tf
    outputs.tf
    variables.tf
```

And we want the whole directory `lib` to be packaged.

With this enhancement path to `lib` might be specified like this

```terraform
module "lambda_edge" {
  source  = "cloudposse/cloudfront-s3-cdn/aws//modules/lambda@edge"
  version = "x.xx.x"

  functions = {
    viewer_request = {
      source_dir   = "${path.module}/lib/"
      runtime      = "nodejs12.x"
      handler      = "index.handler"
      event_type   = "viewer-request"
      include_body = false
    }
  }

  // ...
}
```

## Related

Closes #205