### PR TITLE
Update s3-log-storage to fix #267

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -342,7 +342,7 @@ resource "time_sleep" "wait_for_aws_s3_bucket_settings" {
 
 module "logs" {
   source                   = "cloudposse/s3-log-storage/aws"
-  version                  = "0.26.0"
+  version                  = "1.4.0"
   enabled                  = local.create_cf_log_bucket
   attributes               = var.extra_logs_attributes
   lifecycle_prefix         = local.cloudfront_access_log_prefix


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- I updated the s3-log-storage module to 1.4.0. 

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- fixs #267 
- The old version of this module fails to create a bucket because it tries to create a bucket whose ownership control is `BucketOwnerEnforced` (which is a new default configuration introduced by AWS) first with ACL. 

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
