### PR TITLE
Update README.md to correctly reflect with input documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,16 @@ module "cdn" {
   aliases           = ["assets.cloudposse.com"]
   dns_alias_enabled = true
   parent_zone_name  = "cloudposse.com"
-  s3_origins = {
-    domain_name = module.s3_bucket.bucket_regional_domain_name
-    origin_id   = module.s3_bucket.bucket_id
-    origin_path = null
-    s3_origin_config = {
-      origin_access_identity = null # will get translated to the origin_access_identity used by the origin created by this module.
+  s3_origins = [
+    {
+      domain_name = module.s3_bucket.bucket_regional_domain_name
+      origin_id   = module.s3_bucket.bucket_id
+      origin_path = null
+      s3_origin_config = {
+        origin_access_identity = null # will get translated to the origin_access_identity used by the origin created by this module.
+      }
     }
-  }
+  ]
   origin_groups = {
     primary_origin_id  = null # will get translated to the origin id of the origin created by this module.
     failover_origin_id = module.s3_bucket.bucket_id


### PR DESCRIPTION
## what
Encountered an error while using the example code from documentation

```
│ Error: Invalid value for input variable
│ 
│   on cdn.tf line 12, in module "xxxxxxx":
│   12:   s3_origins = {
│   13:     domain_name = xxxxxxx
│   14:     origin_id   = xxxxxxx
│   15:     origin_path = null
│   16:     s3_origin_config = {
│   17:       origin_access_identity = null
│   18:     }
│   19:   }
│ 
│ The given value is not suitable for module.cdn_srelabs.var.s3_origins
│ declared at
│ /tmp/terraform-data-dir/modules/xxxxxxx/variables.tf:451,1-22: list of
│ object required.
```

## why
* Incorrect documentation