### PR TITLE
Allow optional definition of environment variables to Lambda@Edge

### DIFF
--- a/modules/lambda@edge/main.tf
+++ b/modules/lambda@edge/main.tf
@@ -83,9 +83,7 @@ resource "aws_lambda_function" "default" {
   source_code_hash = each.value.source_zip != null ? sha256(data.local_file.lambda_zip[each.key].content_base64) : data.archive_file.lambda_zip[each.key].output_base64sha256
   publish          = true
   environment {
-    variables = {
-      test = "testvalue"
-    }
+    variables = each.value.env_vars
   }
 }
 

--- a/modules/lambda@edge/main.tf
+++ b/modules/lambda@edge/main.tf
@@ -82,6 +82,11 @@ resource "aws_lambda_function" "default" {
   filename         = each.value.source_zip != null ? data.local_file.lambda_zip[each.key].filename : data.archive_file.lambda_zip[each.key].output_path
   source_code_hash = each.value.source_zip != null ? sha256(data.local_file.lambda_zip[each.key].content_base64) : data.archive_file.lambda_zip[each.key].output_base64sha256
   publish          = true
+  environment {
+    variables = {
+      test = "testvalue"
+    }
+  }
 }
 
 resource "aws_lambda_permission" "allow_cloudfront" {

--- a/modules/lambda@edge/variables.tf
+++ b/modules/lambda@edge/variables.tf
@@ -16,6 +16,9 @@ variable "functions" {
   `runtime` and `handler` correspond to the attributes of the same name in the [lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function)
   resource.
 
+  `env_vars` sets the variables key in environment variable in the [lambda_function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function)
+  resource.
+
   `event_type` and `include_body` correspond to the attributes of the same name in the [Lambda Function association block
   of the cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#lambda-function-association)
   resource.
@@ -31,6 +34,7 @@ variable "functions" {
     handler      = string
     event_type   = string
     include_body = bool
+    env_vars = optional(map(string))
   }))
 
   validation {


### PR DESCRIPTION
## what

Allow optional definition of environment variables to Lambda@Edge module

## why

- I needed to wire up an SQS queue to the Lambda and there was no way to define an environment variable for the queue url in the lambda in the current module.

## references

n/a