### PR TITLE
BucketOwnerEnforced s3 buckets can't have an acl

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -318,7 +318,7 @@ resource "aws_s3_bucket_cors_configuration" "origin" {
 
 resource "aws_s3_bucket_acl" "origin" {
   depends_on = [aws_s3_bucket_ownership_controls.origin]
-  count      = local.create_s3_origin_bucket ? 1 : 0
+  count      = local.create_s3_origin_bucket && var.s3_object_ownership != "BucketOwnerEnforced" ? 1 : 0
 
   bucket = one(aws_s3_bucket.origin).id
   acl    = "private"


### PR DESCRIPTION
## what

disable creating acl resource in that case. 

## why

BucketOwnerEnforeced s3 bucket can't have an acl.

## references

* https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
