### PR TITLE
feature: added ability to set the attributes block_public_acls and ig…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -334,9 +334,9 @@ resource "aws_s3_bucket_public_access_block" "origin" {
   block_public_policy     = var.block_origin_public_access_enabled
   restrict_public_buckets = var.block_origin_public_access_enabled
 
-  # Always block ACL access. We're using policies instead
-  block_public_acls  = true
-  ignore_public_acls = true
+  # We block ACL access by default and use policies instead
+  block_public_acls  = var.block_public_acls
+  ignore_public_acls = var.ignore_public_acls
 }
 
 resource "aws_s3_bucket_ownership_controls" "origin" {

--- a/variables.tf
+++ b/variables.tf
@@ -526,6 +526,18 @@ variable "block_origin_public_access_enabled" {
   description = "When set to 'true' the s3 origin bucket will have public access block enabled"
 }
 
+variable "block_public_acls" {
+  type = bool
+  default = true
+  description = "When set to 'false' s3 origin bucket allows public_acls"
+}
+
+variable "ignore_public_acls" {
+  type = bool
+  default = true
+  description = "When set to 'false' s3 origin bucket considers public_acls"
+}
+
 variable "s3_access_logging_enabled" {
   type        = bool
   default     = null


### PR DESCRIPTION
…nore_public_acls for the origin bucket

## what

-  added optional variables block_public_acls and ignore_public_acls to be able to set those attributes in the resource "aws_s3_bucket_public_access_block". The default is set to true to match the current module config.

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

-  Needed to be able to make the origin bucket optionally publicly accessable

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
