### PR TITLE
Set allowed and cache methods as non nullable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -196,12 +196,14 @@ variable "viewer_protocol_policy" {
 variable "allowed_methods" {
   type        = list(string)
   default     = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+  nullable    = false
   description = "List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) for AWS CloudFront"
 }
 
 variable "cached_methods" {
   type        = list(string)
   default     = ["GET", "HEAD"]
+  nullable    = false
   description = "List of cached methods (e.g. GET, PUT, POST, DELETE, HEAD)"
 }
 


### PR DESCRIPTION
## what

Set allowed_methods and cached_methods as non nullable

Setting nullable to false ensures that the variable value will never be null within the module. If nullable is false and the variable has a default value, then Terraform uses the default when a module input argument is null.

## why

I want to be able to sometimes call this module with explicit `allowed_methods` and `cached_methods` and sometimes just use the module defaults.

As it stands, I cannot do that without making my default value match your default value. It would be better for the module to use its defaults when I pass in `null`

Right now I am hitting

```
Error: Missing required argument

  with module.fanx.module.sdp_assets.module.static_cdn.aws_cloudfront_distribution.default[0],
  on /tmp/terraform-data-dir/modules/fanx.sdp_assets.static_cdn/main.tf line 522, in resource "aws_cloudfront_distribution" "default":
 522:     allowed_methods            = var.allowed_methods

The argument "default_cache_behavior.0.allowed_methods" is required, but no
definition was found.
```

Which I can work around by setting a default on my side, but it isn't ideal behavior

## references

* https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values
* https://stackoverflow.com/questions/72213875/transformer-how-to-call-a-module-with-variables-as-default-value
