### PR TITLE
Allow using multiple cors origins

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -354,15 +354,14 @@ resource "aws_s3_bucket_cors_configuration" "origin" {
 
   bucket = one(aws_s3_bucket.origin).id
 
-  dynamic "cors_rule" {
-    for_each = distinct(compact(concat(var.cors_allowed_origins, var.aliases, var.external_aliases)))
-    content {
-      allowed_headers = var.cors_allowed_headers
-      allowed_methods = var.cors_allowed_methods
-      allowed_origins = [cors_rule.value]
-      expose_headers  = var.cors_expose_headers
-      max_age_seconds = var.cors_max_age_seconds
-    }
+  cors_rule {
+    allowed_headers = var.cors_allowed_headers
+    allowed_methods = var.cors_allowed_methods
+    allowed_origins = sort(
+      distinct(compact(concat(var.cors_allowed_origins, var.aliases, var.external_aliases)))
+    )
+    expose_headers  = var.cors_expose_headers
+    max_age_seconds = var.cors_max_age_seconds
   }
 
   depends_on = [time_sleep.wait_for_aws_s3_bucket_settings]


### PR DESCRIPTION
## what

Enable CORS rules to support multiple origins per rule.  

## why

AWS previously had a bug that restricted each rule to only one `allowed_origin` value. However, it seems this issue has now been fixed, allowing multiple origins per rule.  
We should consolidate the rules as [what we did before](https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/commit/e84f466b453c1d3b2c13b92fa38a2a65ee927a7e) and align them with [terraform-aws-s3-bucket](https://github.com/cloudposse/terraform-aws-s3-bucket/blob/main/main.tf#L156-L167)

## references

https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/issues/22
https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html#cors-allowed-origin
