### PR TITLE
Fix go version in tests

### DIFF
--- a/test/src/go.mod
+++ b/test/src/go.mod
@@ -1,8 +1,8 @@
 module github.com/cloudposse/terraform-aws-cloudfront-s3-cdn
 
-go 1.23.9
+go 1.24
 
-toolchain go1.24.3
+toolchain go1.24.0
 
 require (
 	github.com/gruntwork-io/terratest v0.49.0


### PR DESCRIPTION
## what
- Update go `1.24`

## why
- Error loading shared library libresolv.so.2 in Go 1.20

## References
* https://sweetops.slack.com/archives/G014YEKDH4K/p1746672149263629
* https://github.com/golang/go/issues/59305#issuecomment-1488478737
* https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/294/#issuecomment-2859195553

