### PR TITLE
fix: Resolve unsupported attribute error in S3 website block

### DIFF
--- a/examples/complete/website.tf
+++ b/examples/complete/website.tf
@@ -1,0 +1,34 @@
+module "website_default" {
+  source = "../../"
+
+  namespace = var.namespace
+  stage     = var.stage
+  name      = var.name
+
+  // Distinguish this module instance from the one in main.tf and to prevent S3 bucket name collisions
+  attributes = concat(var.attributes, ["website"])
+
+  cloudfront_access_logging_enabled = false
+
+  website_enabled = true
+
+  context = module.this.context
+}
+
+module "website_redirect_all" {
+  source = "../../"
+
+  namespace = var.namespace
+  stage     = var.stage
+  name      = var.name
+
+  // Distinguish this module instance from the one in main.tf and to prevent S3 bucket name collisions
+  attributes = concat(var.attributes, ["website-redirect-all"])
+
+  cloudfront_access_logging_enabled = false
+
+  website_enabled          = true
+  redirect_all_requests_to = "https://cloudposse.com"
+
+  context = module.this.context
+}

--- a/examples/complete/website.tf
+++ b/examples/complete/website.tf
@@ -5,7 +5,7 @@ module "website_default" {
   stage     = var.stage
   name      = var.name
 
-  // Distinguish this module instance from the one in main.tf and to prevent S3 bucket name collisions
+  // Distinguish this module instance from the one in main.tf and prevent S3 bucket name collisions
   attributes = concat(var.attributes, ["website"])
 
   cloudfront_access_logging_enabled = false
@@ -22,7 +22,7 @@ module "website_redirect_all" {
   stage     = var.stage
   name      = var.name
 
-  // Distinguish this module instance from the one in main.tf and to prevent S3 bucket name collisions
+  // Distinguish this module instance from the one in main.tf and prevent S3 bucket name collisions
   attributes = concat(var.attributes, ["website-redirect-all"])
 
   cloudfront_access_logging_enabled = false

--- a/main.tf
+++ b/main.tf
@@ -319,11 +319,12 @@ resource "aws_s3_bucket" "origin" {
 
   dynamic "website" {
     for_each = var.website_enabled ? local.website_config[var.redirect_all_requests_to == "" ? "default" : "redirect_all"] : []
+    # The lookup is needed to safely access optional website config keys, since locals defines 2 distinct flavours of website config
     content {
-      error_document           = website.value.error_document
-      index_document           = website.value.index_document
-      redirect_all_requests_to = website.value.redirect_all_requests_to
-      routing_rules            = website.value.routing_rules
+      error_document           = lookup(website.value, "error_document", null)
+      index_document           = lookup(website.value, "index_document", null)
+      redirect_all_requests_to = lookup(website.value, "redirect_all_requests_to", null)
+      routing_rules            = lookup(website.value, "routing_rules", null)
     }
   }
 }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Restore `lookup()` calls in `main.tf` to address the `website_enabled = true` use case that was broken when #340 replaced them with explicit variable calls to avoid silent default value assignments. Additionally includes corresponding module instances in the test suite.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

`website_enabled = true` implies a reference to 2 mutually exclusive configurations defined as the `local.website_config` variable. In the default case, `index_document`, `error_document`, and `routing_rules` elements exist, but `redirect_all_requests_to` does not, which leads to the following error:

```
╷
│ Error: Unsupported attribute
│
│   on ../../main.tf line 325, in resource "aws_s3_bucket" "origin":
│  325:       redirect_all_requests_to = website.value.redirect_all_requests_to
│     ├────────────────
│     │ website.value is object with 3 attributes
│
│ This object does not have an attribute named "redirect_all_requests_to".
╵
```

Similarly, `website_enabled = true` combined with `redirect_all_requests_to = "https://example.com"` would result in missing references to the `index_document`, `error_document`, and `routing_rules` fields.

All in all, in this particular case, the `lookup()` usage is definitely justified and does not mean a silent/hidden injection of a variable default.

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
- resolves #354
