### PR TITLE
fix: error: No more than 1 "s3_origin_config" blocks are allowed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -601,7 +601,7 @@ resource "aws_cloudfront_distribution" "default" {
       ) : null
 
       dynamic "s3_origin_config" {
-        for_each = local.origin_access_identity_enabled ? var.s3_origins : []
+        for_each = local.origin_access_identity_enabled ? [1] : []
         content {
           # the following enables specifying the origin_access_identity used by the origin created by this module, prior to the module's creation:
           origin_access_identity = (


### PR DESCRIPTION
##  what

  - Fixed `No more than 1 s3_origin_config blocks are allowed` error when using multiple S3 origins with origin access identity enabled
  - Changed `for_each` from iterating over `var.s3_origins` to using `[1]` to create a single `s3_origin_config` block

##  why

  - AWS CloudFront only allows one s3_origin_config block per origin
  - The previous implementation incorrectly created multiple blocks when multiple S3 origins were configured

## references

fixes #325 

## to reproduce error

1. in examples/complete/main.tf#L102 replace `origin_access_control` with `origin_access_identity`
https://github.com/Eyjafjallajokull/terraform-aws-cloudfront-s3-cdn/blob/96703043867c986ff3fc1550448118111a9f5659/examples/complete/main.tf#L102 
2. `terraform plan` fails with the above error.