### PR TITLE
feat: Enable additional CloudFront real-time metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ module "cdn" {
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
@@ -399,7 +399,7 @@ module "cdn" {
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.2 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.7 |
@@ -407,7 +407,7 @@ module "cdn" {
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_dns"></a> [dns](#module\_dns) | cloudposse/route53-alias/aws | 0.13.0 |
 | <a name="module_logs"></a> [logs](#module\_logs) | cloudposse/s3-log-storage/aws | 1.4.2 |
 | <a name="module_origin_label"></a> [origin\_label](#module\_origin\_label) | cloudposse/label/null | 0.25.0 |
@@ -416,8 +416,9 @@ module "cdn" {
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudfront_distribution.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
+| [aws_cloudfront_monitoring_subscription.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_monitoring_subscription) | resource |
 | [aws_cloudfront_origin_access_control.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
 | [aws_cloudfront_origin_access_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) | resource |
 | [aws_s3_bucket.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
@@ -445,10 +446,11 @@ module "cdn" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_access_log_bucket_name"></a> [access\_log\_bucket\_name](#input\_access\_log\_bucket\_name) | DEPRECATED. Use `s3_access_log_bucket_name` instead. | `string` | `null` | no |
 | <a name="input_acm_certificate_arn"></a> [acm\_certificate\_arn](#input\_acm\_certificate\_arn) | Existing ACM Certificate ARN | `string` | `""` | no |
 | <a name="input_additional_bucket_policy"></a> [additional\_bucket\_policy](#input\_additional\_bucket\_policy) | Additional policies for the bucket. If included in the policies, the variables `${bucket_name}`, `${origin_path}` and `${cloudfront_origin_access_identity_iam_arn}` will be substituted.<br/>It is also possible to override the default policy statements by providing statements with `S3GetObjectForCloudFront` and `S3ListBucketForCloudFront` sid. | `string` | `"{}"` | no |
+| <a name="input_additional_metrics_enabled"></a> [additional\_metrics\_enabled](#input\_additional\_metrics\_enabled) | When set to `true`, enables additional CloudFront real-time metrics (4xx/5xx error rates by HTTP status code, origin latency, and cache hit rate) via a monitoring subscription. | `bool` | `false` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_aliases"></a> [aliases](#input\_aliases) | List of FQDN's - Used to set the Alternate Domain Names (CNAMEs) setting on Cloudfront | `list(string)` | `[]` | no |
 | <a name="input_allow_ssl_requests_only"></a> [allow\_ssl\_requests\_only](#input\_allow\_ssl\_requests\_only) | Set to `true` to require requests to use Secure Socket Layer (HTTPS/SSL). This will explicitly deny access to HTTP requests | `bool` | `true` | no |
@@ -563,7 +565,7 @@ module "cdn" {
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_aliases"></a> [aliases](#output\_aliases) | Aliases of the CloudFront distribution. |
 | <a name="output_cf_access_control_id"></a> [cf\_access\_control\_id](#output\_cf\_access\_control\_id) | CloudFront Origin Access Control ID |
 | <a name="output_cf_arn"></a> [cf\_arn](#output\_cf\_arn) | ARN of AWS CloudFront distribution |

--- a/main.tf
+++ b/main.tf
@@ -770,6 +770,18 @@ resource "aws_cloudfront_distribution" "default" {
   tags = module.this.tags
 }
 
+resource "aws_cloudfront_monitoring_subscription" "default" {
+  count = local.enabled && var.additional_metrics_enabled ? 1 : 0
+
+  distribution_id = aws_cloudfront_distribution.default[0].id
+
+  monitoring_subscription {
+    realtime_metrics_subscription_config {
+      realtime_metrics_subscription_status = "Enabled"
+    }
+  }
+}
+
 module "dns" {
   source           = "cloudposse/route53-alias/aws"
   version          = "0.13.0"

--- a/variables.tf
+++ b/variables.tf
@@ -696,6 +696,12 @@ variable "origin_groups" {
   EOT
 }
 
+variable "additional_metrics_enabled" {
+  type        = bool
+  default     = false
+  description = "When set to `true`, enables additional CloudFront real-time metrics (4xx/5xx error rates by HTTP status code, origin latency, and cache hit rate) via a monitoring subscription."
+}
+
 # Variables below here are DEPRECATED and should not be used anymore
 
 variable "access_log_bucket_name" {


### PR DESCRIPTION
## what

Add `additional_metrics_enabled` variable (default: `false` for backwards compatibility) that provisions an [`aws_cloudfront_monitoring_subscription`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_monitoring_subscription) resource when enabled.

## why

Not all CloudFront metrics are enabled by default. Some (4xx/5xx error rates by HTTP status code, origin latency, and cache hit rate) are hidden behind a monitoring subscription. This adds a convenient switch to enable them when needed.

The `realtime_metrics_subscription_status` value could have been derived from `var.additional_metrics_enabled`, but that would introduce an unexpected resource change across all existing deployments.

## references

A complementary PR to https://github.com/cloudposse/terraform-aws-cloudfront-cdn/pull/162