### PR TITLE
Add blocked_encryption_types to the origin bucket encryption rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ module "cdn" {
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.40.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.2 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7 |
 
@@ -400,7 +400,7 @@ module "cdn" {
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.13.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.40.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.2 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.7 |
 
@@ -457,6 +457,7 @@ module "cdn" {
 | <a name="input_allowed_methods"></a> [allowed\_methods](#input\_allowed\_methods) | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) for AWS CloudFront | `list(string)` | <pre>[<br/>  "DELETE",<br/>  "GET",<br/>  "HEAD",<br/>  "OPTIONS",<br/>  "PATCH",<br/>  "POST",<br/>  "PUT"<br/>]</pre> | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_block_origin_public_access_enabled"></a> [block\_origin\_public\_access\_enabled](#input\_block\_origin\_public\_access\_enabled) | When set to 'true' the s3 origin bucket will have public access block enabled | `bool` | `false` | no |
+| <a name="input_blocked_encryption_types"></a> [blocked\_encryption\_types](#input\_blocked\_encryption\_types) | List of server-side encryption types to block on the origin S3 bucket, e.g. `["SSE-C"]`.<br/>Leave as `null` to keep whatever S3 already has in effect, including the AWS default<br/>that disables SSE-C for buckets created from March 2026 onward. | `list(string)` | `null` | no |
 | <a name="input_bucket_versioning"></a> [bucket\_versioning](#input\_bucket\_versioning) | State of bucket versioning option | `string` | `"Disabled"` | no |
 | <a name="input_cache_policy_id"></a> [cache\_policy\_id](#input\_cache\_policy\_id) | The unique identifier of the existing cache policy to attach to the default cache behavior.<br/>If not provided, this module will add a default cache policy using other provided inputs. | `string` | `null` | no |
 | <a name="input_cached_methods"></a> [cached\_methods](#input\_cached\_methods) | List of cached methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br/>  "GET",<br/>  "HEAD"<br/>]</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -340,13 +340,18 @@ resource "aws_s3_bucket_versioning" "origin" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "origin" {
-  count = var.encryption_enabled && local.create_s3_origin_bucket ? 1 : 0
+  count = local.create_s3_origin_bucket && (var.encryption_enabled || var.blocked_encryption_types != null) ? 1 : 0
 
   bucket = one(aws_s3_bucket.origin).id
 
   rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+    blocked_encryption_types = var.blocked_encryption_types
+
+    dynamic "apply_server_side_encryption_by_default" {
+      for_each = var.encryption_enabled ? [1] : []
+      content {
+        sse_algorithm = "AES256"
+      }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -377,6 +377,16 @@ variable "encryption_enabled" {
   description = "When set to 'true' the resource will have aes256 encryption enabled by default"
 }
 
+variable "blocked_encryption_types" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    List of server-side encryption types to block on the origin S3 bucket, e.g. `["SSE-C"]`.
+    Leave as `null` to keep whatever S3 already has in effect, including the AWS default
+    that disables SSE-C for buckets created from March 2026 onward.
+    EOT
+}
+
 variable "index_document" {
   type        = string
   default     = "index.html"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.13.0"
+      version = ">= 6.40.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## what

Expose the rule's `blocked_encryption_types` argument as a variable defaulting to `null`, which leaves whatever S3 already has in effect untouched.

Blocking an encryption type is independent of choosing a default encryption algorithm, so the resource is no longer gated on `encryption_enabled` alone: it is also created when `blocked_encryption_types` is set, and
`apply_server_side_encryption_by_default` becomes conditional on `encryption_enabled`. Otherwise the new variable would be silently dropped for anyone who turns default encryption off. With `encryption_enabled = true` the rendered rule is byte-for-byte what it was, so existing configurations see no diff.

Raise the AWS provider floor to 6.40.0. The argument first appears in 6.22.0, but only becomes Optional and Computed in 6.40.0; in between, leaving it unset yields a perpetual diff once S3 starts disabling SSE-C on its own.

## why

AWS disables SSE-C by default for general purpose buckets created from March 2026 onward, and buckets opt in or out of that block through the S3 server-side encryption configuration. The module hardcodes the origin bucket's encryption rule to AES256 with no way to reach that setting, so consumers that need SSE-C explicitly blocked have to fork the module or manage the bucket outside of it.

## references

**Provider changelog** — `hashicorp/terraform-provider-aws/CHANGELOG.md`
- **6.22.0** (Nov 20, 2025), FEATURES: *"resource/aws_s3_bucket_server_side_encryption_configuration: Add `rule.blocked_encryption_types` argument"* — [#45105](https://github.com/hashicorp/terraform-provider-aws/issues/45105)
- **6.22.0**, NOTES: *"Starting in March 2026, Amazon S3 will introduce a new default bucket security setting by automatically disabling server-side encryption with customer-provided keys (SSE-C) for all new buckets. Use the `blocked_encryption_types` argument to manage this behavior for specific buckets."*
- **6.40.0** (Apr 8, 2026), BUG FIXES: *"Change `rule.apply_server_side_encryption_by_default.kms_master_key_id`, `rule.blocked_encryption_types`, and `rule.bucket_key_enabled` to Optional and Computed, preventing diffs once SSE-C is disabled for all new general purpose buckets"* — [#47359](https://github.com/hashicorp/terraform-provider-aws/issues/47359). This is the entry that sets the `>= 6.40.0` floor.

**Resource docs** — [registry page](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) / [source markdown](https://github.com/hashicorp/terraform-provider-aws/blob/main/website/docs/r/s3_bucket_server_side_encryption_configuration.html.markdown)
- Valid values: **`SSE-C`** (blocks uploads using customer-provided keys) and **`NONE`** (unblocks all encryption types).
- Their own example uses exactly `blocked_encryption_types = ["SSE-C"]`.
- AWS background: [SSE-C default setting FAQ](https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-s3-c-encryption-setting-faq.html).
